### PR TITLE
Enforce value salt checks and align encrypted transfer tests

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-    skipFiles: ["test/"]
+    skipFiles: ["test/", "hardhat-dependency-compiler/"]
 }

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-    skipFiles: ["test/", "hardhat-dependency-compiler/"]
+    skipFiles: ["test/", "hardhat-dependency-compiler/", "interfaces/"]
 }

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -118,6 +118,7 @@ contract ConfidentialToken is
     error InsufficientBalance();
     error InsufficientGasToken(uint256 required, uint256 available);
     error InvalidPublicKey();
+    error InvalidSaltForTransactionValue();
     error InvalidTransferId(uint256 transferId);
     error NoViewerRegisteredForHolder(address holder);
     error PublicKeyIsNotRegistered(address viewer);
@@ -539,7 +540,15 @@ contract ConfidentialToken is
         _validateDecryptedArguments(decryptedArguments, transferInfo.from, transferInfo.to);
 
         uint256 valueIndex = decryptedArguments.length - 1;
-        value = _decodeBalance(decryptedArguments[valueIndex]);
+        // The transfer value cipher-text is salted with the address that submitted it: the
+        // spender for delegated (transferFrom) flows, otherwise `from` (direct transfer, mint,
+        // burn, EIP-3009). This binds the value to its submitter and prevents replaying a third
+        // party's stored balance/value cipher-text (CONF-01).
+        address expectedSalt = transferInfo.from;
+        if (transferInfo.spender != address(0)) {
+            expectedSalt = transferInfo.spender;
+        }
+        value = _decodeAndVerifyBalance(decryptedArguments[valueIndex], expectedSalt);
 
         (uint256 fromBalance, uint256 toBalance) = _decodeOriginalBalances(decryptedArguments, transferInfo, value);
 
@@ -548,6 +557,7 @@ contract ConfidentialToken is
         bool updatedTo =
             transferInfo.to != address(0) && _lastChanged[transferInfo.to] > transferInfo.submittedBlockNumber;
         if (updatedFrom || updatedTo) {
+            // This MUST be kept always after decoding and verifying Balance (value)
             _reSubmitTransfer(transferInfo, value, plaintextArguments);
             return (false, value);
         }
@@ -575,11 +585,14 @@ contract ConfidentialToken is
         // Resending updated encrypted balances to perform the transfer
         emit CTXResubmitted(msg.sender);
 
-        bytes memory encryptedValue = BITE.encryptTE(encryptTEAddress, abi.encodePacked(value));
-        bytes[] memory encryptedArguments = _encryptArguments(transferInfo.from, transferInfo.to, encryptedValue);
-
-        // TODO: will need transporting once we have encrypted allowances
+        // TODO: will need transporting spender once we have encrypted allowances
+        // Encrypted value was already validated on the first CTX. We clear the spender (so the
+        // allowance is not spent again) and re-salt the value to `from`, which is the holder the
+        // next callback verifies against now that spender == address(0).
+        bytes memory encryptedValue = _encryptTEValueForHolder(transferInfo.from, value);
         transferInfo.spender = address(0);
+        // End of TODO
+        bytes[] memory encryptedArguments = _encryptArguments(transferInfo.from, transferInfo.to, encryptedValue);
         transferInfo.submittedBlockNumber = block.number;
         uint256 numArgs = plaintextArguments.length;
         bytes[] memory updatedPlaintextArguments = new bytes[](numArgs);
@@ -689,7 +702,7 @@ contract ConfidentialToken is
     }
 
     function _updateWithGasPayer(address from, address to, address gasPayer, uint256 value) internal {
-        bytes memory encryptedValue = BITE.encryptTE(encryptTEAddress, abi.encodePacked(value));
+        bytes memory encryptedValue = _encryptTEValueForHolder(from, value);
         _encryptedUpdate({
             from: from,
             to: to,
@@ -741,7 +754,7 @@ contract ConfidentialToken is
     {
         // Values should be padded to 32 bytes before encrypted with BITE TE, to length is strict preventing leaks
         // slither-disable-next-line incorrect-equality
-        require(encryptedValue.length == BITE.TE_RETURN_SIZE_THRESHOLD + 1, ValueWasNotEncryptedCorrectly());
+        require(encryptedValue.length == BITE.TE_RETURN_SIZE_THRESHOLD + 33, ValueWasNotEncryptedCorrectly());
         bytes[] memory encryptedArguments = _encryptArguments(from, to, encryptedValue);
         uint256 extraPlaintextArgumentsLength = extraPlaintextArguments.length;
         bytes[] memory plaintextArguments = new bytes[](2 + extraPlaintextArgumentsLength);
@@ -767,7 +780,7 @@ contract ConfidentialToken is
         address to,
         uint256 value
     ) internal virtual {
-        _encryptedTransferFrom(from, to, BITE.encryptTE(encryptTEAddress, abi.encodePacked(value)));
+        _encryptedTransferFrom(from, to, _encryptTEValueForHolder(msg.sender, value));
     }
 
     function _encryptedTransferFrom(
@@ -810,10 +823,24 @@ contract ConfidentialToken is
         });
     }
 
+    function _encryptTEValueForHolder(
+        address holder,
+        uint256 value
+    )
+        internal
+        view
+        returns (bytes memory encryptedValue)
+    {
+        encryptedValue = BITE.encryptTE(
+            encryptTEAddress,
+            _encodeBalance(holder, value)
+        );
+    }
+
     // Private functions
 
     function _setBalance(address holder, uint256 balance) private {
-        _thresholdBalances[holder] = BITE.encryptTE(encryptTEAddress, abi.encodePacked(balance));
+        _thresholdBalances[holder] = _encryptTEValueForHolder(holder, balance);
         _lastChanged[holder] = block.number;
         if (_viewerIsRegistered(holder)) {
             PublicKey memory viewerPublicKey = _getViewKey(holder);
@@ -835,18 +862,18 @@ contract ConfidentialToken is
     {
         if (transferInfo.from == address(0)) {
             // mint
-            toBalance = _decodeBalance(decryptedArguments[0]);
+            toBalance = _decodeAndVerifyBalance(decryptedArguments[0], transferInfo.to);
         } else if (transferInfo.to == address(0)) {
             // burn
-            fromBalance = _decodeBalance(decryptedArguments[0]);
+            fromBalance = _decodeAndVerifyBalance(decryptedArguments[0], transferInfo.from);
         } else {
             // transfer
             if(transferInfo.spender != address(0)) {
                 // Allowances not encrypted
                 _spendAllowance(transferInfo.from, transferInfo.spender, value);
             }
-            fromBalance = _decodeBalance(decryptedArguments[0]);
-            toBalance = _decodeBalance(decryptedArguments[1]);
+            fromBalance = _decodeAndVerifyBalance(decryptedArguments[0], transferInfo.from);
+            toBalance = _decodeAndVerifyBalance(decryptedArguments[1], transferInfo.to);
         }
     }
 
@@ -917,10 +944,7 @@ contract ConfidentialToken is
     function _getEncryptedBalance(address holder) private view returns (bytes memory encryptedBalance) {
         encryptedBalance = _thresholdBalances[holder];
         if (encryptedBalance.length == 0) {
-            encryptedBalance = BITE.encryptTE(
-                encryptTEAddress,
-                abi.encodePacked(uint256(0))
-            );
+            encryptedBalance = _encryptTEValueForHolder(holder, uint256(0));
         }
     }
 
@@ -957,11 +981,29 @@ contract ConfidentialToken is
         return publicKey.x != bytes32(0) || publicKey.y != bytes32(0);
     }
 
-    function _decodeBalance(bytes calldata encodedBalance) private pure returns (uint256 balance) {
+    function _encodeBalance(address holder, uint256 balance) private pure returns (bytes memory encodedBalance) {
+        return abi.encode(holder, balance);
+    }
+
+    function _decodeBalance(bytes calldata encodedBalance) private pure returns (address holder, uint256 balance) {
         if (encodedBalance.length == 0) {
-            return 0;
+            return (address(0), 0);
         }
-        return uint256(bytes32(encodedBalance));
+        (address holderAddress, uint256 decodedBalance) = abi.decode(encodedBalance, (address, uint256));
+        return (holderAddress, decodedBalance);
+    }
+
+    function _decodeAndVerifyBalance(
+        bytes calldata encodedBalance,
+        address expectedHolder
+    )
+        private
+        pure
+        returns (uint256 balance)
+    {
+        (address holder, uint256 decodedBalance) = _decodeBalance(encodedBalance);
+        require(holder == expectedHolder, InvalidSaltForTransactionValue());
+        return decodedBalance;
     }
 
     /**
@@ -990,18 +1032,18 @@ contract ConfidentialToken is
         } else if (decryptedArguments.length == 3) {
             // token transfer
             require(
-                decryptedArguments[1].length == 32 || decryptedArguments[1].length == 0,
+                decryptedArguments[1].length == 64 || decryptedArguments[1].length == 0,
                 DecryptionBadFormat()
             );
         } else {
             revert DecryptionBadFormat();
         }
         require(
-            decryptedArguments[0].length == 32 || decryptedArguments[0].length == 0,
+            decryptedArguments[0].length == 64 || decryptedArguments[0].length == 0,
             DecryptionBadFormat()
         );
         require(
-            decryptedArguments[valueIndex].length == 32,
+            decryptedArguments[valueIndex].length == 64,
             DecryptionBadFormat()
         );
     }

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -752,7 +752,7 @@ contract ConfidentialToken is
         internal
         virtual
     {
-        // Values should be padded to 32 bytes before encrypted with BITE TE, to length is strict preventing leaks
+        // Values should be padded exactly to 64 bytes (abi.encode(address,uint256))before encrypted with BITE TE
         // slither-disable-next-line incorrect-equality
         require(encryptedValue.length == BITE.TE_RETURN_SIZE_THRESHOLD + 33, ValueWasNotEncryptedCorrectly());
         bytes[] memory encryptedArguments = _encryptArguments(from, to, encryptedValue);
@@ -943,7 +943,7 @@ contract ConfidentialToken is
 
     function _getEncryptedBalance(address holder) private view returns (bytes memory encryptedBalance) {
         encryptedBalance = _thresholdBalances[holder];
-        // This is allways correct, as an empty encrypted balance is a zero balance.
+        // This is always correct, as an empty encrypted balance is a zero balance.
         // Empty balances only occur when a holder has never had any transfers before
         // slither-disable-next-line incorrect-equality
         if (encryptedBalance.length == 0) {

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -765,7 +765,7 @@ contract ConfidentialToken is
         internal
         virtual
     {
-        // Values should be padded exactly to 64 bytes (abi.encode(address,uint256))before encrypted with BITE TE
+        // Values should be padded exactly to 64 bytes (abi.encode(address,uint256)) before encrypted with BITE TE
         // slither-disable-next-line incorrect-equality
         require(encryptedValue.length == BITE.TE_RETURN_SIZE_THRESHOLD + 33, ValueWasNotEncryptedCorrectly());
         bytes[] memory encryptedArguments = _encryptArguments(from, to, encryptedValue);

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -323,6 +323,19 @@ contract ConfidentialToken is
     }
 
     /// @inheritdoc IConfidentialToken
+    function encryptValue(
+        address holder,
+        uint256 value
+    )
+        external
+        view
+        override
+        returns (bytes memory encryptedValue)
+    {
+        return _encryptTEValueForHolder(holder, value);
+    }
+
+    /// @inheritdoc IConfidentialToken
     function gasTokenBalanceOf(address holder) external view override returns (uint256 balance) {
         return _gasTokenBalance[holder];
     }

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -943,6 +943,9 @@ contract ConfidentialToken is
 
     function _getEncryptedBalance(address holder) private view returns (bytes memory encryptedBalance) {
         encryptedBalance = _thresholdBalances[holder];
+        // This is allways correct, as an empty encrypted balance is a zero balance.
+        // Empty balances only occur when a holder has never had any transfers before
+        // slither-disable-next-line incorrect-equality
         if (encryptedBalance.length == 0) {
             encryptedBalance = _encryptTEValueForHolder(holder, uint256(0));
         }

--- a/contracts/ConfidentialWrapper.sol
+++ b/contracts/ConfidentialWrapper.sol
@@ -32,7 +32,6 @@ import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/I
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
-import { BITE } from "@skalenetwork/bite-solidity/BITE.sol";
 import { ConfidentialToken, IConfidentialToken } from "./ConfidentialToken.sol";
 import { IConfidentialWrapper } from "./interfaces/IConfidentialWrapper.sol";
 
@@ -247,7 +246,7 @@ contract ConfidentialWrapper is
             revert ERC20InvalidReceiver(to);
         }
         require(value != 0, ZeroValue());
-        bytes memory encryptedValue = BITE.encryptTE(encryptTEAddress, abi.encodePacked(value));
+        bytes memory encryptedValue = _encryptTEValueForHolder(from, value);
         bytes[] memory extraArgs = new bytes[](1);
         extraArgs[0] = abi.encodePacked(to);
         _encryptedUpdateExtended({

--- a/contracts/interfaces/IConfidentialToken.sol
+++ b/contracts/interfaces/IConfidentialToken.sol
@@ -295,6 +295,15 @@ interface IConfidentialToken is IBiteSupplicant {
     /// @return encryptedBalance The encrypted balance of the holder
     function encryptedBalanceOf(address holder) external view returns (bytes memory encryptedBalance);
 
+    /// @notice Encrypts `value` for `holder` using Threshold Encryption
+    /// @dev Produces a cipher-text suitable for use in `encryptedTransfer` and `encryptedTransferFrom`.
+    ///      The cipher-text binds `holder` as the salt — only a transaction submitted by `holder`
+    ///      (or by a spender in `encryptedTransferFrom`) will pass the on-callback salt check.
+    /// @param holder The address used as the encryption salt; must match the submitter at callback time
+    /// @param value The plaintext token amount to encrypt
+    /// @return encryptedValue TE-encrypted bytes ready to pass to `encryptedTransfer` or `encryptedTransferFrom`
+    function encryptValue(address holder, uint256 value) external view returns (bytes memory encryptedValue);
+
     /// @notice Gets the gas token balance of a holder
     /// @param holder The address of the holder
     /// @return balance The gas token balance of the holder

--- a/docs/ConfidentialToken.md
+++ b/docs/ConfidentialToken.md
@@ -463,6 +463,31 @@ function encryptedBalanceOf(address holder) external view returns (bytes encrypt
 | ---- | ---- | ----------- |
 | encryptedBalance | bytes | The encrypted balance of the holder |
 
+### encryptValue
+
+Encrypts `value` for `holder` using Threshold Encryption
+
+```solidity
+function encryptValue(address holder, uint256 value) external view returns (bytes encryptedValue)
+```
+
+**dev:** _Produces a cipher-text suitable for use in `encryptedTransfer` and `encryptedTransferFrom`.
+     The cipher-text binds `holder` as the salt — only a transaction submitted by `holder`
+     (or by a spender in `encryptedTransferFrom`) will pass the on-callback salt check._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| holder | address | The address used as the encryption salt; must match the submitter at callback time |
+| value | uint256 | The plaintext token amount to encrypt |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| encryptedValue | bytes | TE-encrypted bytes ready to pass to `encryptedTransfer` or `encryptedTransferFrom` |
+
 ### gasTokenBalanceOf
 
 Gets the gas token balance of a holder

--- a/docs/ConfidentialToken.md
+++ b/docs/ConfidentialToken.md
@@ -104,6 +104,12 @@ error InsufficientGasToken(uint256 required, uint256 available)
 error InvalidPublicKey()
 ```
 
+### InvalidSaltForTransactionValue
+
+```solidity
+error InvalidSaltForTransactionValue()
+```
+
 ### InvalidTransferId
 
 ```solidity
@@ -760,4 +766,10 @@ function _encryptedTransfer(address from, address to, bytes value) internal virt
 | from | address | Address to transfer tokens from |
 | to | address | Address to transfer tokens to |
 | value | bytes | TE-encrypted amount of tokens to be transferred |
+
+### _encryptTEValueForHolder
+
+```solidity
+function _encryptTEValueForHolder(address holder, uint256 value) internal view returns (bytes encryptedValue)
+```
 

--- a/docs/interfaces/IConfidentialToken.md
+++ b/docs/interfaces/IConfidentialToken.md
@@ -676,6 +676,31 @@ function encryptedBalanceOf(address holder) external view returns (bytes encrypt
 | ---- | ---- | ----------- |
 | encryptedBalance | bytes | The encrypted balance of the holder |
 
+### encryptValue
+
+Encrypts `value` for `holder` using Threshold Encryption
+
+```solidity
+function encryptValue(address holder, uint256 value) external view returns (bytes encryptedValue)
+```
+
+**dev:** _Produces a cipher-text suitable for use in `encryptedTransfer` and `encryptedTransferFrom`.
+     The cipher-text binds `holder` as the salt — only a transaction submitted by `holder`
+     (or by a spender in `encryptedTransferFrom`) will pass the on-callback salt check._
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| holder | address | The address used as the encryption salt; must match the submitter at callback time |
+| value | uint256 | The plaintext token amount to encrypt |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| encryptedValue | bytes | TE-encrypted bytes ready to pass to `encryptedTransfer` or `encryptedTransferFrom` |
+
 ### gasTokenBalanceOf
 
 Gets the gas token balance of a holder

--- a/migrations/deploy.ts
+++ b/migrations/deploy.ts
@@ -165,7 +165,7 @@ export class TokenDeployer {
         console.log(`Deploying ${contractName}...`);
         const factory = await ethers.getContractFactory(contractName);
         const contract = await factory.deploy(...constructorArgs);
-        await contract.deploymentTransaction()?.wait();
+        await contract.waitForDeployment();
         const deployedAddress = await ethers.resolveAddress(contract);
         console.log(`Deployed ${contractName} at: ${deployedAddress}`);
         this._storeDeployment(contractName, deployedAddress);

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -2,12 +2,11 @@
 
 import "chai/register-should";
 import { ethers } from "hardhat";
-import { AddressLike, BaseWallet, BigNumberish, BytesLike, HDNodeWallet, Wallet } from "ethers";
+import { AddressLike, BaseWallet, BigNumberish, BytesLike, HDNodeWallet } from "ethers";
 import { expect } from "chai";
 import { BiteMock, ConfidentialToken } from "../typechain-types";
-import { withMintedTokens } from "./tools/fixtures";
-import { getPublicKey } from "./tools/cryptography";
-import { balanceOf, feedAccounts, nowPlusSeconds } from "./tools/helpers";
+import { withEIP3009Setup } from "./tools/fixtures";
+import { balanceOf, nowPlusSeconds } from "./tools/helpers";
 
 const ENCRYPTED_TRANSFER_WITH_AUTHORIZATION_TYPEHASH = ethers.id(
     "TransferWithAuthorization(address from,address to,bytes value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
@@ -27,41 +26,10 @@ describe("ConfidentialEIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
-    before(async () => {
-        alice = Wallet.createRandom(ethers.provider);
-        bob = Wallet.createRandom(ethers.provider);
-        charlie = Wallet.createRandom(ethers.provider);
-    });
-
     beforeEach(async () => {
-        const { bite: deployedBite, token: deployedToken } =
-            await withMintedTokens();
-        bite = deployedBite;
-        token = deployedToken;
+        ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         domainSeparator = await token.DOMAIN_SEPARATOR();
         nonce = ethers.hexlify(ethers.randomBytes(32));
-
-        await feedAccounts([
-            alice,
-            bob,
-            charlie
-        ]);
-
-        for (const user of [alice, bob, charlie]) {
-            await token
-                .connect(user)
-                .fundWithGasToken(user, { value: ethers.parseEther("3") });
-        }
-
-        await token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
-        await bite.sendCallback();
-        await token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
-        await bite.sendCallback();
-        await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-        await bite.sendCallback();
-
-        await token.transfer(alice, initialBalance);
-        await bite.sendCallback();
     });
 
     const encryptValue = async (from: AddressLike, value: BigNumberish): Promise<string> => {
@@ -91,7 +59,7 @@ describe("ConfidentialEIP3009", () => {
     describe("encryptedTransferWithAuthorization", () => {
         let transferParams: TransferParams;
 
-        before(async () => {
+        beforeEach(() => {
             transferParams = {
                 from: alice,
                 to: bob,
@@ -448,7 +416,7 @@ describe("ConfidentialEIP3009", () => {
 
     describe("encryptedReceiveWithAuthorization", () => {
         let receiveParams: TransferParams;
-        before(async () => {
+        beforeEach(() => {
             receiveParams = {
                 from: alice,
                 to: charlie,

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -26,6 +26,12 @@ describe("ConfidentialEIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
+    before(async function() {
+        // warmup the fixture with larger timeout. This runs only once and is loaded in all following tests
+        this.timeout(60_000);
+        await withEIP3009Setup();
+    });
+
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         domainSeparator = await token.DOMAIN_SEPARATOR();

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -1,5 +1,6 @@
 // cspell:words typehash
 
+import "chai/register-should";
 import { ethers } from "hardhat";
 import { AddressLike, BaseWallet, BigNumberish, BytesLike, HDNodeWallet, Wallet } from "ethers";
 import { expect } from "chai";
@@ -63,8 +64,10 @@ describe("ConfidentialEIP3009", () => {
         await bite.sendCallback();
     });
 
-    const encryptValue = async (value: BigNumberish): Promise<string> => {
-        return bite.encryptTE(ethers.zeroPadValue(ethers.toBeHex(value), 32));
+    const encryptValue = async (from: AddressLike, value: BigNumberish): Promise<string> => {
+        return bite.encryptTE(
+            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [await ethers.resolveAddress(from), value])
+        );
     };
 
     it("has the expected type hashes", async () => {
@@ -100,8 +103,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("executes a transfer when a valid authorization is given", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(value);
-
+            const encryptedValue = await encryptValue(from, value);
             // create an authorization to transfer money from Alice to Bob and sign
             // with Alice's key
             const { v, r, s } = await signEncryptedTransferAuthorization(
@@ -114,13 +116,11 @@ describe("ConfidentialEIP3009", () => {
                 domainSeparator,
                 alice
             );
-
             // check initial balance
             expect(await balanceOf(token, bite, from)).to.equal(10e6);
             expect(await balanceOf(token, bite, to)).to.equal(0);
 
             expect(await token.authorizationState(from, nonce)).to.be.equal(false);
-
             // a third-party, Charlie (not Alice) submits the signed authorization
             await token.connect(charlie).encryptedTransferWithAuthorization(
                 from,
@@ -133,7 +133,6 @@ describe("ConfidentialEIP3009", () => {
                 r,
                 s
             ).should.emit(token, "AuthorizationUsed").withArgs(from, nonce);
-
             await bite.sendCallback().should.emit(token, "Transfer(address,address)").withArgs(from, to);
 
             // check that balance is updated
@@ -148,7 +147,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature does not match given parameters", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedTransferAuthorization(
@@ -163,7 +162,7 @@ describe("ConfidentialEIP3009", () => {
             );
 
             // try to cheat by passing a different encrypted value
-            const wrongEncryptedValue = await encryptValue(Number(value) * 2);
+            const wrongEncryptedValue = await encryptValue(from, Number(value) * 2);
 
             await token.connect(charlie).encryptedTransferWithAuthorization(
                 from,
@@ -180,7 +179,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature is not signed with the right key", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create an authorization to transfer money from Alice to Bob, but
             // sign with Bob's key instead of Alice's
@@ -212,7 +211,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is not yet valid", async () => {
             const { from, to, value, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization that won't be valid until 10 seconds
             // later
@@ -245,7 +244,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is expired", async () => {
             const { from, to, value, validAfter } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization that expires immediately
             const validBefore = await nowPlusSeconds(0);
@@ -278,7 +277,7 @@ describe("ConfidentialEIP3009", () => {
             const { from, to, validAfter, validBefore } = transferParams;
             // create a signed authorization
             const value = 1e6;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedTransferAuthorization(
                 from,
@@ -321,7 +320,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization has a nonce that has already been used by the signer", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization
             const authorization = await signEncryptedTransferAuthorization(
@@ -350,7 +349,7 @@ describe("ConfidentialEIP3009", () => {
 
             // create another authorization with the same nonce, but with different
             // parameters
-            const smallerEncryptedValue = await encryptValue(1e6);
+            const smallerEncryptedValue = await encryptValue(from, 1e6);
             const authorization2 = await signEncryptedTransferAuthorization(
                 from,
                 to,
@@ -381,7 +380,7 @@ describe("ConfidentialEIP3009", () => {
             // create a signed authorization that attempts to transfer an amount
             // that exceeds the sender's balance
             const value = initialBalance + 1;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedTransferAuthorization(
                 from,
@@ -418,7 +417,7 @@ describe("ConfidentialEIP3009", () => {
                 validAfter,
                 validBefore,
             } = transferParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(owner, value);
 
             // create a signed authorization for a receive (wrong type)
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -461,7 +460,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("executes a transfer when a valid authorization is submitted by the payee", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a receive authorization to transfer money from Alice to Charlie
             // and sign with Alice's key
@@ -509,7 +508,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the caller is not the payee", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -545,7 +544,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature does not match given parameters", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -560,7 +559,7 @@ describe("ConfidentialEIP3009", () => {
             );
 
             // try to cheat by passing a different encrypted value
-            const wrongEncryptedValue = await encryptValue(Number(value) * 2);
+            const wrongEncryptedValue = await encryptValue(from, Number(value) * 2);
 
             await token.connect(charlie).encryptedReceiveWithAuthorization(
                 from,
@@ -577,7 +576,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature is not signed with the right key", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create an authorization to transfer money from Alice to Charlie, but
             // sign with Bob's key instead of Alice's
@@ -609,7 +608,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is not yet valid", async () => {
             const { from, to, value, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization that won't be valid until 10 seconds
             // later
@@ -641,7 +640,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is expired", async () => {
             const { from, to, value, validAfter } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization that expires immediately
             const validBefore = await nowPlusSeconds(0);
@@ -674,7 +673,7 @@ describe("ConfidentialEIP3009", () => {
             const { from, to, validAfter, validBefore } = receiveParams;
             // create a signed authorization
             const value = 1e6;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedReceiveAuthorization(
                 from,
@@ -717,7 +716,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization has a nonce that has already been used by the signer", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             // create a signed authorization
             const authorization = await signEncryptedReceiveAuthorization(
@@ -748,7 +747,7 @@ describe("ConfidentialEIP3009", () => {
 
             // create another authorization with the same nonce, but with different
             // parameters
-            const smallerEncryptedValue = await encryptValue(1e6);
+            const smallerEncryptedValue = await encryptValue(from, 1e6);
             const authorization2 = await signEncryptedReceiveAuthorization(
                 from,
                 to,
@@ -778,7 +777,7 @@ describe("ConfidentialEIP3009", () => {
             // create a signed authorization that attempts to transfer an amount
             // that exceeds the sender's balance
             const value = initialBalance + 1;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedReceiveAuthorization(
                 from,
@@ -819,7 +818,7 @@ describe("ConfidentialEIP3009", () => {
                 validAfter,
                 validBefore,
             } = receiveParams;
-            const encryptedValue = await encryptValue(value);
+            const encryptedValue = await encryptValue(owner, value);
 
             // create a signed authorization for a transfer (wrong type)
             const { v, r, s } = await signEncryptedTransferAuthorization(

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -40,12 +40,6 @@ describe("ConfidentialEIP3009", () => {
         nonce = ethers.hexlify(ethers.randomBytes(32));
     });
 
-    const encryptValue = async (from: AddressLike, value: BigNumberish): Promise<string> => {
-        return bite.encryptTE(
-            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [await ethers.resolveAddress(from), value])
-        );
-    };
-
     it("has the expected type hashes", async () => {
         expect(await token.ENCRYPTED_TRANSFER_WITH_AUTHORIZATION_TYPEHASH()).to.equal(
             ENCRYPTED_TRANSFER_WITH_AUTHORIZATION_TYPEHASH
@@ -79,7 +73,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("executes a transfer when a valid authorization is given", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
             // create an authorization to transfer money from Alice to Bob and sign
             // with Alice's key
             const { v, r, s } = await signEncryptedTransferAuthorization(
@@ -123,7 +117,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature does not match given parameters", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedTransferAuthorization(
@@ -138,7 +132,7 @@ describe("ConfidentialEIP3009", () => {
             );
 
             // try to cheat by passing a different encrypted value
-            const wrongEncryptedValue = await encryptValue(from, Number(value) * 2);
+            const wrongEncryptedValue = await token.encryptValue(from, Number(value) * 2);
 
             await token.connect(charlie).encryptedTransferWithAuthorization(
                 from,
@@ -155,7 +149,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature is not signed with the right key", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create an authorization to transfer money from Alice to Bob, but
             // sign with Bob's key instead of Alice's
@@ -187,7 +181,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is not yet valid", async () => {
             const { from, to, value, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization that won't be valid until 10 seconds
             // later
@@ -220,7 +214,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is expired", async () => {
             const { from, to, value, validAfter } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization that expires immediately
             const validBefore = await nowPlusSeconds(0);
@@ -253,7 +247,7 @@ describe("ConfidentialEIP3009", () => {
             const { from, to, validAfter, validBefore } = transferParams;
             // create a signed authorization
             const value = 1e6;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedTransferAuthorization(
                 from,
@@ -296,7 +290,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization has a nonce that has already been used by the signer", async () => {
             const { from, to, value, validAfter, validBefore } = transferParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization
             const authorization = await signEncryptedTransferAuthorization(
@@ -325,7 +319,7 @@ describe("ConfidentialEIP3009", () => {
 
             // create another authorization with the same nonce, but with different
             // parameters
-            const smallerEncryptedValue = await encryptValue(from, 1e6);
+            const smallerEncryptedValue = await token.encryptValue(from, 1e6);
             const authorization2 = await signEncryptedTransferAuthorization(
                 from,
                 to,
@@ -356,7 +350,7 @@ describe("ConfidentialEIP3009", () => {
             // create a signed authorization that attempts to transfer an amount
             // that exceeds the sender's balance
             const value = initialBalance + 1;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedTransferAuthorization(
                 from,
@@ -393,7 +387,7 @@ describe("ConfidentialEIP3009", () => {
                 validAfter,
                 validBefore,
             } = transferParams;
-            const encryptedValue = await encryptValue(owner, value);
+            const encryptedValue = await token.encryptValue(owner, value);
 
             // create a signed authorization for a receive (wrong type)
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -436,7 +430,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("executes a transfer when a valid authorization is submitted by the payee", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a receive authorization to transfer money from Alice to Charlie
             // and sign with Alice's key
@@ -484,7 +478,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the caller is not the payee", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -520,7 +514,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature does not match given parameters", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization
             const { v, r, s } = await signEncryptedReceiveAuthorization(
@@ -535,7 +529,7 @@ describe("ConfidentialEIP3009", () => {
             );
 
             // try to cheat by passing a different encrypted value
-            const wrongEncryptedValue = await encryptValue(from, Number(value) * 2);
+            const wrongEncryptedValue = await token.encryptValue(from, Number(value) * 2);
 
             await token.connect(charlie).encryptedReceiveWithAuthorization(
                 from,
@@ -552,7 +546,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the signature is not signed with the right key", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create an authorization to transfer money from Alice to Charlie, but
             // sign with Bob's key instead of Alice's
@@ -584,7 +578,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is not yet valid", async () => {
             const { from, to, value, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization that won't be valid until 10 seconds
             // later
@@ -616,7 +610,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization is expired", async () => {
             const { from, to, value, validAfter } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization that expires immediately
             const validBefore = await nowPlusSeconds(0);
@@ -649,7 +643,7 @@ describe("ConfidentialEIP3009", () => {
             const { from, to, validAfter, validBefore } = receiveParams;
             // create a signed authorization
             const value = 1e6;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedReceiveAuthorization(
                 from,
@@ -692,7 +686,7 @@ describe("ConfidentialEIP3009", () => {
 
         it("reverts if the authorization has a nonce that has already been used by the signer", async () => {
             const { from, to, value, validAfter, validBefore } = receiveParams;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             // create a signed authorization
             const authorization = await signEncryptedReceiveAuthorization(
@@ -723,7 +717,7 @@ describe("ConfidentialEIP3009", () => {
 
             // create another authorization with the same nonce, but with different
             // parameters
-            const smallerEncryptedValue = await encryptValue(from, 1e6);
+            const smallerEncryptedValue = await token.encryptValue(from, 1e6);
             const authorization2 = await signEncryptedReceiveAuthorization(
                 from,
                 to,
@@ -753,7 +747,7 @@ describe("ConfidentialEIP3009", () => {
             // create a signed authorization that attempts to transfer an amount
             // that exceeds the sender's balance
             const value = initialBalance + 1;
-            const encryptedValue = await encryptValue(from, value);
+            const encryptedValue = await token.encryptValue(from, value);
 
             const { v, r, s } = await signEncryptedReceiveAuthorization(
                 from,
@@ -794,7 +788,7 @@ describe("ConfidentialEIP3009", () => {
                 validAfter,
                 validBefore,
             } = receiveParams;
-            const encryptedValue = await encryptValue(owner, value);
+            const encryptedValue = await token.encryptValue(owner, value);
 
             // create a signed authorization for a transfer (wrong type)
             const { v, r, s } = await signEncryptedTransferAuthorization(

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -34,6 +34,8 @@ describe("ConfidentialEIP3009", () => {
 
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
+        const latestBlock = await ethers.provider.getBlock("latest");
+        await ethers.provider.send("evm_setNextBlockTimestamp", [latestBlock!.timestamp + 1]);
         domainSeparator = await token.DOMAIN_SEPARATOR();
         nonce = ethers.hexlify(ethers.randomBytes(32));
     });

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -354,11 +354,7 @@ describe("ConfidentialToken", () => {
         );
         await bite.sendCallback();
 
-        // Must be correctly encoded to hide the value, otherwise it leaks the length of the value
-        // Plaintext is abi.encode(from, amount) matching _encodeBalance on the contract
-        const encryptedAmount = await bite.encryptTE(
-            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [owner.address, amount])
-        );
+        const encryptedAmount = await token.encryptValue(owner.address, amount);
 
         await token.connect(owner).encryptedTransfer(recipient, encryptedAmount);
 
@@ -392,12 +388,8 @@ describe("ConfidentialToken", () => {
 
         await token.connect(owner).approve(spender, amount);
 
-        // Must be correctly encoded to hide the value, otherwise it leaks the length of the value.
-        // For transferFrom the value is salted to the spender (the submitter), matching the
-        // `spender != 0 ? spender : from` rule enforced on callback.
-        const encryptedAmount = await bite.encryptTE(
-            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [spender.address, amount])
-        );
+        // For transferFrom the value must be salted to the spender, not the owner
+        const encryptedAmount = await token.encryptValue(spender.address, amount);
 
         await token.connect(spender).encryptedTransferFrom(owner, recipient, encryptedAmount);
 
@@ -1249,11 +1241,6 @@ describe("ConfidentialToken", () => {
 
     describe("Stress-testing salted encrypted data", () => {
         // This section tests that the salted encryption of values prevents replaying encrypted balance values arbitrarily, which would otherwise allow an attacker to learn a victim's balance or transfer value.
-        const encryptValueFor = (bite: BiteMock, holder: string, amount: bigint) =>
-            bite.encryptTE(
-                ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [holder, amount])
-            );
-
         it("should reject replaying a victim's stored balance cipher-text (passive-victim disclosure)", async () => {
             const { token, bite, owner: victim } = await withMintedTokens();
             const [, attacker, sink] = await ethers.getSigners();
@@ -1266,7 +1253,7 @@ describe("ConfidentialToken", () => {
             // Attacker reconstructs the victim's world-readable _thresholdBalances[victim] cipher-text
             // In the real world, the attacker would read storage from _thresholdBalances[victim].
             // Here in local tests, this is the same
-            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+            const victimBalanceCt = await token.encryptValue(victim.address, victimBalance);
 
             // Attacker fully sets up: registers their own viewer and funds gas for two callbacks
             await token.fundWithGasToken(attacker, { value: (await token.callbackFee()) * 2n });
@@ -1290,7 +1277,7 @@ describe("ConfidentialToken", () => {
             await bite.sendCallback();
             const victimBalance = await balanceOf(token, bite, victim);
 
-            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+            const victimBalanceCt = await token.encryptValue(victim.address, victimBalance);
 
             // Attacker holds NO tokens (would fail any >= check) and only funds the callback gas
             await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
@@ -1312,7 +1299,7 @@ describe("ConfidentialToken", () => {
             await bite.sendCallback();
 
             // Owner crafts a self-salted value cipher-text and uses it in a legitimate transfer
-            const ownerValueCt = await encryptValueFor(bite, owner.address, amount);
+            const ownerValueCt = await token.encryptValue(owner.address, amount);
             await token.connect(owner).encryptedTransfer(recipient, ownerValueCt);
             await bite.sendCallback();
 
@@ -1331,7 +1318,7 @@ describe("ConfidentialToken", () => {
             await token.connect(victim).setViewerPublicKey(await getPublicKey(victim));
             await bite.sendCallback();
             const victimBalance = await balanceOf(token, bite, victim);
-            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+            const victimBalanceCt = await token.encryptValue(victim.address, victimBalance);
 
             await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
 
@@ -1357,7 +1344,7 @@ describe("ConfidentialToken", () => {
             await token.connect(recipient2).setViewerPublicKey(await getPublicKey(recipient2), { value: gasFunding });
             await bite.sendCallback();
 
-            const ownValueCt = await encryptValueFor(bite, owner.address, amount);
+            const ownValueCt = await token.encryptValue(owner.address, amount);
 
             // Self-salted cipher-text used in a legitimate transfer
             await token.connect(owner).encryptedTransfer(recipient, ownValueCt);
@@ -1382,7 +1369,7 @@ describe("ConfidentialToken", () => {
             // requires holder == from unconditionally (no amount == 0 short-circuit), so even a
             // zero-valued foreign-salted cipher-text is rejected. This is what closes the residual
             // zero / non-zero balance oracle (see the test below).
-            const zeroCt = await encryptValueFor(bite, victim.address, 0n);
+            const zeroCt = await token.encryptValue(victim.address, 0n);
 
             await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
             await token.connect(attacker).encryptedTransfer(sink, zeroCt);
@@ -1405,7 +1392,7 @@ describe("ConfidentialToken", () => {
 
             // Honest zero-value transfers are salted to the rightful sender, so holder == from
             // holds and the callback finalizes without moving any tokens.
-            const ownZeroCt = await encryptValueFor(bite, owner.address, 0n);
+            const ownZeroCt = await token.encryptValue(owner.address, 0n);
             await token.connect(owner).encryptedTransfer(recipient, ownZeroCt);
             await expect(bite.sendCallback()).to.not.be.reverted;
 
@@ -1481,7 +1468,7 @@ describe("ConfidentialToken", () => {
 
             // A real, self-salted cipher-text of the exact valid length is accepted and finalizes.
             const amount = ethers.parseEther("1");
-            const validCt = await encryptValueFor(bite, owner.address, amount);
+            const validCt = await token.encryptValue(owner.address, amount);
             expect(ethers.dataLength(validCt)).to.equal(VALID_TE_PAYLOAD_SIZE);
 
             await token.connect(recipient).setViewerPublicKey(
@@ -1511,8 +1498,8 @@ describe("ConfidentialToken", () => {
 
             // These are exactly the world-readable cipher-texts an attacker reads from storage; the
             // attacker does NOT need to know the underlying amounts to replay the raw bytes.
-            const richBalanceCt = await encryptValueFor(bite, richVictim.address, richBalance);
-            const zeroBalanceCt = await encryptValueFor(bite, zeroVictim.address, 0n);
+            const richBalanceCt = await token.encryptValue(richVictim.address, richBalance);
+            const zeroBalanceCt = await token.encryptValue(zeroVictim.address, 0n);
 
             await token.fundWithGasToken(attacker, { value: (await token.callbackFee()) * 2n });
 

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -355,7 +355,10 @@ describe("ConfidentialToken", () => {
         await bite.sendCallback();
 
         // Must be correctly encoded to hide the value, otherwise it leaks the length of the value
-        const encryptedAmount = await bite.encryptTE(ethers.zeroPadValue(ethers.toBeHex(amount), 32));
+        // Plaintext is abi.encode(from, amount) matching _encodeBalance on the contract
+        const encryptedAmount = await bite.encryptTE(
+            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [owner.address, amount])
+        );
 
         await token.connect(owner).encryptedTransfer(recipient, encryptedAmount);
 
@@ -389,8 +392,12 @@ describe("ConfidentialToken", () => {
 
         await token.connect(owner).approve(spender, amount);
 
-        // Must be correctly encoded to hide the value, otherwise it leaks the length of the value
-        const encryptedAmount = await bite.encryptTE(ethers.zeroPadValue(ethers.toBeHex(amount), 32));
+        // Must be correctly encoded to hide the value, otherwise it leaks the length of the value.
+        // For transferFrom the value is salted to the spender (the submitter), matching the
+        // `spender != 0 ? spender : from` rule enforced on callback.
+        const encryptedAmount = await bite.encryptTE(
+            ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [spender.address, amount])
+        );
 
         await token.connect(spender).encryptedTransferFrom(owner, recipient, encryptedAmount);
 
@@ -1237,6 +1244,292 @@ describe("ConfidentialToken", () => {
             const callbackTx = await bite.sendCallback();
 
             await expect(callbackTx).to.not.emit(token, "TransferValueEncryptedForRecipient");
+        });
+    });
+
+    describe("Stress-testing salted encrypted data", () => {
+        // This section tests that the salted encryption of values prevents replaying encrypted balance values arbitrarily, which would otherwise allow an attacker to learn a victim's balance or transfer value.
+        const encryptValueFor = (bite: BiteMock, holder: string, amount: bigint) =>
+            bite.encryptTE(
+                ethers.AbiCoder.defaultAbiCoder().encode(["address", "uint256"], [holder, amount])
+            );
+
+        it("should reject replaying a victim's stored balance cipher-text (passive-victim disclosure)", async () => {
+            const { token, bite, owner: victim } = await withMintedTokens();
+            const [, attacker, sink] = await ethers.getSigners();
+
+            // Victim merely holds tokens and registers a viewer, so a balance cipher-text is stored
+            await token.connect(victim).setViewerPublicKey(await getPublicKey(victim));
+            await bite.sendCallback();
+            const victimBalance = await balanceOf(token, bite, victim);
+
+            // Attacker reconstructs the victim's world-readable _thresholdBalances[victim] cipher-text
+            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+
+            // Attacker fully sets up: registers their own viewer and funds gas for two callbacks
+            await token.fundWithGasToken(attacker, { value: (await token.callbackFee()) * 2n });
+            await token.connect(attacker).setViewerPublicKey(await getPublicKey(attacker));
+            await bite.sendCallback();
+
+            // Attacker replays the victim's cipher-text as their own transfer to a sink they control
+            await token.connect(attacker).encryptedTransfer(sink, victimBalanceCt);
+
+            // Callback must revert: salt (victim) does not match the transfer's `from` (attacker),
+            // so the decrypted balance is never re-encrypted to the attacker's viewer key
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+
+        it("should not leak balance information (revert is InvalidSalt, not InsufficientBalance)", async () => {
+            const { token, bite, owner: victim } = await withMintedTokens();
+            const [, attacker, sink] = await ethers.getSigners();
+
+            await token.connect(victim).setViewerPublicKey(await getPublicKey(victim));
+            await bite.sendCallback();
+            const victimBalance = await balanceOf(token, bite, victim);
+
+            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+
+            // Attacker holds NO tokens (would fail any >= check) and only funds the callback gas
+            await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
+            await token.connect(attacker).encryptedTransfer(sink, victimBalanceCt);
+
+            // The salt check fails before any balance comparison runs, so the revert reason is
+            // independent of whether the attacker's balance is >= or < the victim's balance.
+            // This denies the binary-search oracle described in CONF-01.
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+
+        it("should reject replaying a value cipher-text observed from another sender's transfer", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient, attacker, sink] = await ethers.getSigners();
+            const amount = ethers.parseEther("10");
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+
+            // Owner crafts a self-salted value cipher-text and uses it in a legitimate transfer
+            const ownerValueCt = await encryptValueFor(bite, owner.address, amount);
+            await token.connect(owner).encryptedTransfer(recipient, ownerValueCt);
+            await bite.sendCallback();
+
+            // Attacker observed `ownerValueCt` in calldata and replays it as their own transfer
+            await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
+            await token.connect(attacker).encryptedTransfer(sink, ownerValueCt);
+
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+
+        it("should reject replaying a victim's balance cipher-text via transferFrom without allowance", async () => {
+            const { token, bite, owner: victim } = await withMintedTokens();
+            const [, attacker, sink] = await ethers.getSigners();
+
+            await token.connect(victim).setViewerPublicKey(await getPublicKey(victim));
+            await bite.sendCallback();
+            const victimBalance = await balanceOf(token, bite, victim);
+            const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
+
+            await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
+
+            // Via transferFrom the value is salted to the spender (the attacker), so the victim's
+            // balance cipher-text (salted to the victim) fails the salt check on callback before
+            // the allowance is even consulted.
+            await token.connect(attacker).encryptedTransferFrom(victim, sink, victimBalanceCt);
+
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+
+        it("should allow a sender to reuse their OWN value cipher-text for legitimate transfers", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient, recipient2] = await ethers.getSigners();
+            const amount = ethers.parseEther("5");
+            const gasFunding = ethers.parseEther("1.0");
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+            await token.connect(recipient).setViewerPublicKey(await getPublicKey(recipient), { value: gasFunding });
+            await bite.sendCallback();
+            await token.connect(recipient2).setViewerPublicKey(await getPublicKey(recipient2), { value: gasFunding });
+            await bite.sendCallback();
+
+            const ownValueCt = await encryptValueFor(bite, owner.address, amount);
+
+            // Self-salted cipher-text used in a legitimate transfer
+            await token.connect(owner).encryptedTransfer(recipient, ownValueCt);
+            await bite.sendCallback();
+            expect(await balanceOf(token, bite, recipient)).to.equal(amount);
+
+            // Reusing the same self-salted cipher-text is benign: it only ever moves the sender's
+            // own tokens and discloses the value only to the sender's own viewer key
+            await token.connect(owner).encryptedTransfer(recipient2, ownValueCt);
+            await bite.sendCallback();
+            expect(await balanceOf(token, bite, recipient2)).to.equal(amount);
+        });
+
+        it("should reject replaying a foreign-salted cipher-text even when it encodes zero", async () => {
+            const { token, bite, owner: victim } = await withMintedTokens();
+            const [, attacker, sink] = await ethers.getSigners();
+
+            await token.connect(victim).setViewerPublicKey(await getPublicKey(victim));
+            await bite.sendCallback();
+
+            // Cipher-text salted with the victim but encoding a zero amount. _decodeAndVerifyBalance
+            // requires holder == from unconditionally (no amount == 0 short-circuit), so even a
+            // zero-valued foreign-salted cipher-text is rejected. This is what closes the residual
+            // zero / non-zero balance oracle (see the test below).
+            const zeroCt = await encryptValueFor(bite, victim.address, 0n);
+
+            await token.fundWithGasToken(attacker, { value: await token.callbackFee() });
+            await token.connect(attacker).encryptedTransfer(sink, zeroCt);
+
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+
+        it("should allow a legitimate self-salted zero-value transfer", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient] = await ethers.getSigners();
+            const gasFunding = ethers.parseEther("1.0");
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+            await token.connect(recipient).setViewerPublicKey(await getPublicKey(recipient), { value: gasFunding });
+            await bite.sendCallback();
+
+            const ownerBalanceBefore = await balanceOf(token, bite, owner);
+
+            // Honest zero-value transfers are salted to the rightful sender, so holder == from
+            // holds and the callback finalizes without moving any tokens.
+            const ownZeroCt = await encryptValueFor(bite, owner.address, 0n);
+            await token.connect(owner).encryptedTransfer(recipient, ownZeroCt);
+            await expect(bite.sendCallback()).to.not.be.reverted;
+
+            expect(await balanceOf(token, bite, owner)).to.equal(ownerBalanceBefore);
+            expect(await balanceOf(token, bite, recipient)).to.equal(0n);
+        });
+
+        // Submission-time size gating
+        //
+        // The caller-supplied `value` is validated synchronously in _encryptedUpdateExtended:
+        //   require(encryptedValue.length == BITE.TE_RETURN_SIZE_THRESHOLD + 33, ...)
+        // TE_RETURN_SIZE_THRESHOLD is 323, so the only accepted length is 356 bytes. Any other
+        // length MUST revert in the submitting transaction itself.
+        const VALID_TE_PAYLOAD_SIZE = 356;
+
+        it("should reject any incorrectly-sized TE payload at submission time, not on callback", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient] = await ethers.getSigners();
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+
+            const invalidSizes = [
+                "0x",                                                  // empty
+                ethers.hexlify(ethers.randomBytes(1)),                 // single byte
+                ethers.hexlify(ethers.randomBytes(VALID_TE_PAYLOAD_SIZE - 1)), // one byte short
+                ethers.hexlify(ethers.randomBytes(VALID_TE_PAYLOAD_SIZE + 1)), // one byte long
+                ethers.hexlify(ethers.randomBytes(VALID_TE_PAYLOAD_SIZE * 2))  // far too long
+            ];
+
+            const callbackFee = await token.callbackFee();
+            for (const payload of invalidSizes) {
+                const gasTokenBefore = await token.gasTokenBalanceOf(owner);
+
+                // Rejected synchronously in the submitting transaction
+                await token.connect(owner).encryptedTransfer(recipient, payload)
+                    .should.be.revertedWithCustomError(token, "ValueWasNotEncryptedCorrectly");
+
+                // No CTX scheduled and no fee charged: behavior is fully gated up-front
+                expect(await token.gasTokenBalanceOf(owner)).to.equal(gasTokenBefore);
+                expect(callbackFee).to.be.greaterThan(0n);
+            }
+
+            // Every attempt reverted at submission, so the callback queue is empty
+            await bite.sendCallback().should.be.revertedWithCustomError(bite, "NoCallbacksQueued");
+        });
+
+        it("should reject an incorrectly-sized payload via transferFrom at submission time too", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, spender, recipient] = await ethers.getSigners();
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+            await token.fundWithGasToken(spender, { value: await token.callbackFee() });
+
+            const wrongSize = ethers.hexlify(ethers.randomBytes(VALID_TE_PAYLOAD_SIZE - 1));
+            const gasTokenBefore = await token.gasTokenBalanceOf(spender);
+
+            await token.connect(spender).encryptedTransferFrom(owner, recipient, wrongSize)
+                .should.be.revertedWithCustomError(token, "ValueWasNotEncryptedCorrectly");
+
+            // Spender's gas token untouched; nothing was queued
+            expect(await token.gasTokenBalanceOf(spender)).to.equal(gasTokenBefore);
+            await bite.sendCallback().should.be.revertedWithCustomError(bite, "NoCallbacksQueued");
+        });
+
+        it("should accept a correctly-sized payload at submission and only enforce content in the callback", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient] = await ethers.getSigners();
+
+            await token.connect(owner).setViewerPublicKey(await getPublicKey(owner));
+            await bite.sendCallback();
+
+            // A real, self-salted cipher-text of the exact valid length is accepted and finalizes.
+            const amount = ethers.parseEther("1");
+            const validCt = await encryptValueFor(bite, owner.address, amount);
+            expect(ethers.dataLength(validCt)).to.equal(VALID_TE_PAYLOAD_SIZE);
+
+            await token.connect(recipient).setViewerPublicKey(
+                await getPublicKey(recipient), { value: ethers.parseEther("1.0") }
+            );
+            await bite.sendCallback();
+
+            await expect(token.connect(owner).encryptedTransfer(recipient, validCt)).to.not.be.reverted;
+            await bite.sendCallback();
+            expect(await balanceOf(token, bite, recipient)).to.equal(amount);
+        });
+
+        it("does not leak a victim's zero/non-zero balance", async () => {
+            const { token, bite, owner: richVictim } = await withMintedTokens();
+            const [, zeroVictim, attacker, sink] = await ethers.getSigners();
+            const gasFunding = ethers.parseEther("1.0");
+
+            // Both victims simply register a viewer (passive participants). richVictim holds the
+            // minted supply; zeroVictim holds nothing.
+            await token.connect(richVictim).setViewerPublicKey(await getPublicKey(richVictim));
+            await bite.sendCallback();
+            await token.connect(zeroVictim).setViewerPublicKey(await getPublicKey(zeroVictim), { value: gasFunding });
+            await bite.sendCallback();
+
+            const richBalance = await balanceOf(token, bite, richVictim);
+            expect(richBalance).to.be.greaterThan(0n);
+
+            // These are exactly the world-readable cipher-texts an attacker reads from storage; the
+            // attacker does NOT need to know the underlying amounts to replay the raw bytes.
+            const richBalanceCt = await encryptValueFor(bite, richVictim.address, richBalance);
+            const zeroBalanceCt = await encryptValueFor(bite, zeroVictim.address, 0n);
+
+            await token.fundWithGasToken(attacker, { value: (await token.callbackFee()) * 2n });
+
+            // Identical attacker action against each victim now yields the SAME outcome: both
+            // foreign-salted replays revert with InvalidSaltForTransactionValue, so the attacker
+            // learns nothing distinguishing about either victim's balance. The two cases are run
+            // from a shared snapshot because a reverting callback stays at the head of the BiteMock
+            // queue, which would otherwise prevent the second callback from ever executing.
+            const snapshot = await takeSnapshot();
+
+            await token.connect(attacker).encryptedTransfer(sink, richBalanceCt);
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+
+            await snapshot.restore();
+
+            await token.connect(attacker).encryptedTransfer(sink, zeroBalanceCt);
+            await expect(bite.sendCallback())
+                .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
         });
     });
 });

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -1264,6 +1264,8 @@ describe("ConfidentialToken", () => {
             const victimBalance = await balanceOf(token, bite, victim);
 
             // Attacker reconstructs the victim's world-readable _thresholdBalances[victim] cipher-text
+            // In the real world, the attacker would read storage from _thresholdBalances[victim].
+            // Here in local tests, this is the same
             const victimBalanceCt = await encryptValueFor(bite, victim.address, victimBalance);
 
             // Attacker fully sets up: registers their own viewer and funds gas for two callbacks

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -29,6 +29,12 @@ describe("EIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
+    before(async function() {
+        // warmup the fixture with larger timeout. This runs only once and is loaded in all following tests
+        this.timeout(60_000);
+        await withEIP3009Setup();
+    });
+
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         domainSeparator = await token.DOMAIN_SEPARATOR();

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -37,6 +37,8 @@ describe("EIP3009", () => {
 
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
+        const latestBlock = await ethers.provider.getBlock("latest");
+        await ethers.provider.send("evm_setNextBlockTimestamp", [latestBlock!.timestamp + 1]);
         domainSeparator = await token.DOMAIN_SEPARATOR();
         nonce = ethers.hexlify(ethers.randomBytes(32));
     });

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -1,12 +1,11 @@
 // cspell:words typehash
 
 import { ethers } from "hardhat";
-import { AddressLike, BaseWallet, BigNumberish, HDNodeWallet, Wallet } from "ethers";
+import { AddressLike, BaseWallet, BigNumberish, HDNodeWallet } from "ethers";
 import { expect } from "chai";
 import { BiteMock, ConfidentialToken } from "../typechain-types";
-import { withMintedTokens } from "./tools/fixtures";
-import { getPublicKey } from "./tools/cryptography";
-import { balanceOf, feedAccounts, nowPlusSeconds } from "./tools/helpers";
+import { withEIP3009Setup } from "./tools/fixtures";
+import { balanceOf, nowPlusSeconds } from "./tools/helpers";
 
 const TRANSFER_WITH_AUTHORIZATION_TYPEHASH = ethers.id(
     "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
@@ -30,41 +29,10 @@ describe("EIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
-    before(async () => {
-        alice = Wallet.createRandom(ethers.provider);
-        bob = Wallet.createRandom(ethers.provider);
-        charlie = Wallet.createRandom(ethers.provider);
-    });
-
     beforeEach(async () => {
-        const { bite: deployedBite, token: deployedToken } =
-            await withMintedTokens();
-        bite = deployedBite;
-        token = deployedToken;
+        ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         domainSeparator = await token.DOMAIN_SEPARATOR();
         nonce = ethers.hexlify(ethers.randomBytes(32));
-
-        await feedAccounts([
-            alice,
-            bob,
-            charlie
-        ]);
-
-        for (const user of [alice, bob, charlie]) {
-            await token
-                .connect(user)
-                .fundWithGasToken(user, { value: ethers.parseEther("3") });
-        }
-
-        await token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
-        await bite.sendCallback();
-        await token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
-        await bite.sendCallback();
-        await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-        await bite.sendCallback();
-
-        await token.transfer(alice, initialBalance);
-        await bite.sendCallback();
     });
 
     it("has the expected type hashes", async () => {
@@ -92,7 +60,7 @@ describe("EIP3009", () => {
     describe("transferWithAuthorization", () => {
         let transferParams: TransferParams;
 
-        before(async () => {
+        beforeEach(() => {
             transferParams = {
                 from: alice,
                 to: bob,
@@ -438,7 +406,7 @@ describe("EIP3009", () => {
 
     describe("receiveWithAuthorization", () => {
         let receiveParams: TransferParams;
-        before(async () => {
+        beforeEach(() => {
             receiveParams = {
                 from: alice,
                 to: charlie,
@@ -817,7 +785,7 @@ describe("EIP3009", () => {
 
     describe("cancelAuthorization", () => {
         let receiveParams: TransferParams;
-        before(async () => {
+        beforeEach(() => {
             receiveParams = {
                 from: alice,
                 to: charlie,

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -2,12 +2,15 @@ import {
     loadFixture
 } from "@nomicfoundation/hardhat-network-helpers";
 import { ethers } from "hardhat";
+import { HDNodeWallet, Wallet } from "ethers";
 import { AccessManager, MintableConfidentialToken } from "../../typechain-types";
 import {
     deployMintableWithTokenDeployer,
     deployWrapperWithTokenDeployer
 } from "./tokenDeployerHelpers";
 import { deployTestERC20 } from "../../scripts/deployTestERC20";
+import { getPublicKey } from "./cryptography";
+import { feedAccounts } from "./helpers";
 
 // cspell:words ECIES
 
@@ -132,9 +135,42 @@ const wrappedFixture = async () => {
     }
 }
 
+const eip3009Fixture = async () => {
+    const alice = Wallet.createRandom(ethers.provider) as HDNodeWallet;
+    const bob = Wallet.createRandom(ethers.provider) as HDNodeWallet;
+    const charlie = Wallet.createRandom(ethers.provider) as HDNodeWallet;
+
+    // Inline minting setup — avoids nesting loadFixture calls
+    const minted = ethers.parseEther("1000");
+    const gasTokenBalance = ethers.parseEther("1.0");
+    const context = await deployMintableFixture();
+    await context.owner.sendTransaction({
+        to: await ethers.resolveAddress(context.token),
+        value: gasTokenBalance
+    });
+    await context.token.mint(context.owner, minted);
+    await context.bite.sendCallback();
+
+    await feedAccounts([alice, bob, charlie]);
+    for (const user of [alice, bob, charlie]) {
+        await context.token.connect(user).fundWithGasToken(user, { value: ethers.parseEther("3") });
+    }
+    await context.token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
+    await context.bite.sendCallback();
+    await context.token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
+    await context.bite.sendCallback();
+    await context.token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+    await context.bite.sendCallback();
+    await context.token.transfer(alice, 10e6);
+    await context.bite.sendCallback();
+
+    return { ...context, alice, bob, charlie, minted };
+};
+
 // External functions
 
 export const cleanMintableDeployment = async () => loadFixture(deployMintableFixture);
 export const withMintedTokens = async () => loadFixture(mintedFixture);
 export const cleanWrapperDeployment = async () => loadFixture(deployWrapperFixture);
 export const withWrappedTokens = async () => loadFixture(wrappedFixture);
+export const withEIP3009Setup = async () => loadFixture(eip3009Fixture);

--- a/test/tools/helpers.ts
+++ b/test/tools/helpers.ts
@@ -18,12 +18,11 @@ export const balanceOf = async (token: EncryptedBalanceToken, bite: BiteMock, ho
     // We use the registered view key for mock decryption
     // In production the private key of the view key registered should be used
     const publicKey = await token.publicKeys(await token.viewerAddresses(holder));
-    return ethers.toBigInt(
-        await bite.decryptECIES(
-            encryptedBalance,
-            await bite.pubKeyToUint256(publicKey.x, publicKey.y)
-        )
+    const decrypted = await bite.decryptECIES(
+        encryptedBalance,
+        await bite.pubKeyToUint256(publicKey.x, publicKey.y)
     );
+    return ethers.toBigInt(decrypted);
 }
 
 


### PR DESCRIPTION
This pull request introduces significant improvements to the confidentiality and integrity of encrypted token balances and transfer values in `ConfidentialToken.sol`. The main change is the introduction of a per-holder "salt" (the holder's address) when encoding and encrypting balances and transfer values. This prevents replay attacks and the re-use of storage encrypted values by unexpected participants

**Key changes:**

### Confidentiality and integrity improvements

* All encrypted balances stored are now encoded with the holder's address as a salt, binding ciphertexts to specific accounts.
* Introduced a new error, `InvalidSaltForTransactionValue`, which is thrown if a decoded value is not salted for the expected holder.
* Transfers triggered with encrypted values expect the salt value to be the the message sender.

### Validation and format changes

* All decrypted balances/values are now 64 bytes (bytes32(address) + uint256), and all validation checks and documentation updated accordingly.

### Test and documentation updates

* All tests updated to encode the holder address in encrypted values, ensuring test coverage for the new scheme. 
* Documentation updated to describe the new error and helper function. 
* New tests introduced to ensure the previously exploitable pattern is covered + others.

------
Fixes https://github.com/skalenetwork/internal-support/issues/1471