### PR TITLE
Add payable functions to pass gas token during different operations

### DIFF
--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -172,7 +172,7 @@ contract ConfidentialToken is
     }
 
     /// @inheritdoc IConfidentialToken
-    function encryptedTransfer(address to, bytes calldata value) external override {
+    function encryptedTransfer(address to, bytes calldata value) external payable override {
         _encryptedTransfer(msg.sender, to, value);
     }
 
@@ -181,7 +181,8 @@ contract ConfidentialToken is
         address from,
         address to,
         bytes calldata value
-    ) external override {
+    ) external payable override {
+        fundWithGasToken(msg.sender);
         _encryptedTransferFrom(from, to, value);
     }
 
@@ -827,6 +828,7 @@ contract ConfidentialToken is
         if (to == address(0)) {
             revert ERC20InvalidReceiver(address(0));
         }
+        fundWithGasToken(msg.sender);
         _encryptedUpdate({
             from: from,
             to: to,

--- a/contracts/ConfidentialToken.sol
+++ b/contracts/ConfidentialToken.sol
@@ -187,7 +187,7 @@ contract ConfidentialToken is
     }
 
     /// @inheritdoc IConfidentialToken
-    function requestDecryptHistoricTransfer(bytes calldata encryptedTransferData) external override {
+    function requestDecryptHistoricTransfer(bytes calldata encryptedTransferData) external payable override {
         // This function is kept for backward compatibility with older versions of the contract
         requestDecryptHistoricTransferFor(encryptedTransferData, msg.sender);
     }
@@ -390,9 +390,11 @@ contract ConfidentialToken is
         address historicViewer
     )
         public
+        payable
         override
         onlyRegisteredUser(historicViewer)
     {
+        fundWithGasToken(msg.sender);
         bytes[] memory encryptedArguments = new bytes[](1);
         encryptedArguments[0] = encryptedTransferData;
 

--- a/contracts/ConfidentialWrapper.sol
+++ b/contracts/ConfidentialWrapper.sol
@@ -131,6 +131,12 @@ contract ConfidentialWrapper is
         underlying().safeTransfer(account, value);
     }
 
+    /// @inheritdoc IConfidentialWrapper
+    function withdrawToWithGasToken(address account, uint256 value) external payable override returns (bool success) {
+        fundWithGasToken(msg.sender);
+        return withdrawTo(account, value);
+    }
+
     // Public functions
 
     ///@inheritdoc ConfidentialToken

--- a/contracts/ConfidentialWrapper.sol
+++ b/contracts/ConfidentialWrapper.sol
@@ -120,6 +120,12 @@ contract ConfidentialWrapper is
 
 
     /// @inheritdoc IConfidentialWrapper
+    function depositForWithGasToken(address account, uint256 value) external payable override returns (bool success) {
+        fundWithGasToken(msg.sender);
+        return depositFor(account, value);
+    }
+
+    /// @inheritdoc IConfidentialWrapper
     function releaseTo(address account, uint256 value) external override {
         requestedMints[_msgSender()] -= value;
         underlying().safeTransfer(account, value);

--- a/contracts/eip3009/ConfidentialEIP3009.sol
+++ b/contracts/eip3009/ConfidentialEIP3009.sol
@@ -86,7 +86,7 @@ abstract contract ConfidentialEIP3009 is EIP3009 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external {
+    ) external payable {
         _transferWithAuthorization({
             typeHash: ENCRYPTED_TRANSFER_WITH_AUTHORIZATION_TYPEHASH,
             from: from,

--- a/contracts/eip3009/ConfidentialEIP3009.sol
+++ b/contracts/eip3009/ConfidentialEIP3009.sol
@@ -126,7 +126,7 @@ abstract contract ConfidentialEIP3009 is EIP3009 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external {
+    ) external payable {
         require(to == msg.sender, CallerMustBeThePayee(msg.sender, to));
 
         _transferWithAuthorization({

--- a/contracts/interfaces/IConfidentialToken.sol
+++ b/contracts/interfaces/IConfidentialToken.sol
@@ -219,13 +219,13 @@ interface IConfidentialToken is IBiteSupplicant {
     /// @notice Transfers tokens to another holder
     /// @param to The address of the recipient holder
     /// @param value The TE-encrypted amount of tokens to transfer
-    function encryptedTransfer(address to, bytes calldata value) external;
+    function encryptedTransfer(address to, bytes calldata value) external payable;
 
     /// @notice Transfers tokens from one holder to another using allowance
     /// @param from The address of the sender holder
     /// @param to The address of the recipient holder
     /// @param value The TE-encrypted amount of tokens to transfer
-    function encryptedTransferFrom(address from, address to, bytes calldata value) external;
+    function encryptedTransferFrom(address from, address to, bytes calldata value) external payable;
 
     /// @notice Requests decryption of a single historic encrypted transfer payload with msg.sender as the viewer
     /// @dev Charges callbackFee from msg.sender even if not authorized to decrypt the payload

--- a/contracts/interfaces/IConfidentialToken.sol
+++ b/contracts/interfaces/IConfidentialToken.sol
@@ -230,13 +230,16 @@ interface IConfidentialToken is IBiteSupplicant {
     /// @notice Requests decryption of a single historic encrypted transfer payload with msg.sender as the viewer
     /// @dev Charges callbackFee from msg.sender even if not authorized to decrypt the payload
     /// @param encryptedTransferData TE-encrypted transfer payload emitted by the token
-    function requestDecryptHistoricTransfer(bytes calldata encryptedTransferData) external;
+    function requestDecryptHistoricTransfer(bytes calldata encryptedTransferData) external payable;
 
     /// @notice Requests decryption of a single historic encrypted transfer payload
     /// @dev Charges callbackFee from msg.sender even if not authorized to decrypt the payload
     /// @param encryptedTransferData TE-encrypted transfer payload emitted by the token
     /// @param historicViewer Address of the viewer who will receive the decrypted transfer event if authorized
-    function requestDecryptHistoricTransferFor(bytes calldata encryptedTransferData, address historicViewer) external;
+    function requestDecryptHistoricTransferFor(
+        bytes calldata encryptedTransferData,
+        address historicViewer
+    ) external payable;
 
     /// @notice Removes all historic view permissions for a viewer for msg.sender's history
     /// @dev Resets time window and clears explicitly authorized transfer IDs

--- a/contracts/interfaces/IConfidentialWrapper.sol
+++ b/contracts/interfaces/IConfidentialWrapper.sol
@@ -34,7 +34,8 @@ import { IConfidentialToken } from "./IConfidentialToken.sol";
 /// @notice Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 interface IConfidentialWrapper is IConfidentialToken {
 
-    /// @notice depositFor like function that allows to top up gas token wallet of the sender in the same transaction
+    /// @notice depositFor-like function
+    /// @notice that allows the sender to top up their gas token balance in the same transaction
     /// @param account The address to credit the wrapped tokens to
     /// @param value The amount of tokens to wrap
     /// @return success Whether the deposit was successful
@@ -57,7 +58,8 @@ interface IConfidentialWrapper is IConfidentialToken {
         address initialAuthority
     ) external;
 
-    /// @notice withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
+    /// @notice withdrawTo-like function
+    /// @notice that allows the sender to top up their gas token balance in the same transaction
     /// @param account The address to release the underlying tokens to
     /// @param value The amount of tokens to release
     /// @return success Whether the withdrawal was successful

--- a/contracts/interfaces/IConfidentialWrapper.sol
+++ b/contracts/interfaces/IConfidentialWrapper.sol
@@ -56,4 +56,10 @@ interface IConfidentialWrapper is IConfidentialToken {
         string calldata version_,
         address initialAuthority
     ) external;
+
+    /// @notice withdrawTo like function that allows to top up gas token wallet in the same transaction
+    /// @param account The address to release the underlying tokens to
+    /// @param value The amount of tokens to release
+    /// @return success Whether the withdrawal was successful
+    function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success);
 }

--- a/contracts/interfaces/IConfidentialWrapper.sol
+++ b/contracts/interfaces/IConfidentialWrapper.sol
@@ -34,6 +34,12 @@ import { IConfidentialToken } from "./IConfidentialToken.sol";
 /// @notice Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 interface IConfidentialWrapper is IConfidentialToken {
 
+    /// @notice depositFor like function that allows to top up gas token wallet in the same transaction
+    /// @param account The address to credit the wrapped tokens to
+    /// @param value The amount of tokens to wrap
+    /// @return success Whether the deposit was successful
+    function depositForWithGasToken(address account, uint256 value) external payable returns (bool success);
+
     /// @notice Releases the caller's pending wrapped tokens to `account`.
     /// @notice Only the recipient of a prior `depositFor` (i.e. an address with a
     /// non-zero `requestedMints` entry) can call this; the depositor cannot.

--- a/contracts/interfaces/IConfidentialWrapper.sol
+++ b/contracts/interfaces/IConfidentialWrapper.sol
@@ -34,7 +34,7 @@ import { IConfidentialToken } from "./IConfidentialToken.sol";
 /// @notice Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 interface IConfidentialWrapper is IConfidentialToken {
 
-    /// @notice depositFor like function that allows to top up gas token wallet in the same transaction
+    /// @notice depositFor like function that allows to top up gas token wallet of the sender in the same transaction
     /// @param account The address to credit the wrapped tokens to
     /// @param value The amount of tokens to wrap
     /// @return success Whether the deposit was successful
@@ -57,7 +57,7 @@ interface IConfidentialWrapper is IConfidentialToken {
         address initialAuthority
     ) external;
 
-    /// @notice withdrawTo like function that allows to top up gas token wallet in the same transaction
+    /// @notice withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
     /// @param account The address to release the underlying tokens to
     /// @param value The amount of tokens to release
     /// @return success Whether the withdrawal was successful

--- a/docs/ConfidentialToken.md
+++ b/docs/ConfidentialToken.md
@@ -237,7 +237,7 @@ function encryptedTransferFrom(address from, address to, bytes value) external p
 Requests decryption of a single historic encrypted transfer payload with msg.sender as the viewer
 
 ```solidity
-function requestDecryptHistoricTransfer(bytes encryptedTransferData) external
+function requestDecryptHistoricTransfer(bytes encryptedTransferData) external payable
 ```
 
 **dev:** _Charges callbackFee from msg.sender even if not authorized to decrypt the payload_
@@ -556,7 +556,7 @@ function initialize(string name_, string symbol_, string version_, address initi
 Requests decryption of a single historic encrypted transfer payload
 
 ```solidity
-function requestDecryptHistoricTransferFor(bytes encryptedTransferData, address historicViewer) public
+function requestDecryptHistoricTransferFor(bytes encryptedTransferData, address historicViewer) public payable
 ```
 
 **dev:** _Charges callbackFee from msg.sender even if not authorized to decrypt the payload_

--- a/docs/ConfidentialToken.md
+++ b/docs/ConfidentialToken.md
@@ -206,7 +206,7 @@ function onDecrypt(bytes[] decryptedArguments, bytes[] plaintextArguments) exter
 Transfers tokens to another holder
 
 ```solidity
-function encryptedTransfer(address to, bytes value) external
+function encryptedTransfer(address to, bytes value) external payable
 ```
 
 #### Parameters
@@ -221,7 +221,7 @@ function encryptedTransfer(address to, bytes value) external
 Transfers tokens from one holder to another using allowance
 
 ```solidity
-function encryptedTransferFrom(address from, address to, bytes value) external
+function encryptedTransferFrom(address from, address to, bytes value) external payable
 ```
 
 #### Parameters

--- a/docs/ConfidentialWrapper.md
+++ b/docs/ConfidentialWrapper.md
@@ -80,7 +80,7 @@ function initialize(contract IERC20Metadata underlyingToken, string version_, ad
 
 ### depositForWithGasToken
 
-depositFor like function that allows to top up gas token wallet in the same transaction
+depositFor like function that allows to top up gas token wallet of the sender in the same transaction
 
 ```solidity
 function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
@@ -118,7 +118,7 @@ function releaseTo(address account, uint256 value) external
 
 ### withdrawToWithGasToken
 
-withdrawTo like function that allows to top up gas token wallet in the same transaction
+withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
 
 ```solidity
 function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)

--- a/docs/ConfidentialWrapper.md
+++ b/docs/ConfidentialWrapper.md
@@ -57,26 +57,14 @@ constructor(bool proxyMode, contract IERC20Metadata underlyingToken, string vers
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| proxyMode | bool | If true, disables initializers for proxy deployment.                  If false, initializes the contract directly. |
-| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. Ignored when proxyMode is true. |
-| version_ | string | Version of the wrapper. Ignored when proxyMode is true. |
-| initialAuthority | address | Initial authority address. Ignored when proxyMode is true. |
+| account | address | The address to credit the wrapped tokens to |
+| value | uint256 | The amount of tokens to wrap |
 
-### initialize
-
-Initializes the contract for proxy deployment.
-
-```solidity
-function initialize(contract IERC20Metadata underlyingToken, string version_, address initialAuthority) external
-```
-
-#### Parameters
+#### Return Values
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. |
-| version_ | string | Version of the wrapper. |
-| initialAuthority | address | Initial authority address. |
+| success | bool | Whether the deposit was successful |
 
 ### releaseTo
 

--- a/docs/ConfidentialWrapper.md
+++ b/docs/ConfidentialWrapper.md
@@ -80,7 +80,8 @@ function initialize(contract IERC20Metadata underlyingToken, string version_, ad
 
 ### depositForWithGasToken
 
-depositFor like function that allows to top up gas token wallet of the sender in the same transaction
+depositFor-like function
+that allows the sender to top up their gas token balance in the same transaction
 
 ```solidity
 function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
@@ -118,7 +119,8 @@ function releaseTo(address account, uint256 value) external
 
 ### withdrawToWithGasToken
 
-withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
+withdrawTo-like function
+that allows the sender to top up their gas token balance in the same transaction
 
 ```solidity
 function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)

--- a/docs/ConfidentialWrapper.md
+++ b/docs/ConfidentialWrapper.md
@@ -83,6 +83,27 @@ function releaseTo(address account, uint256 value) external
 | account | address | The address to release the underlying tokens to |
 | value | uint256 | The amount of tokens to release |
 
+### withdrawToWithGasToken
+
+withdrawTo like function that allows to top up gas token wallet in the same transaction
+
+```solidity
+function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address to release the underlying tokens to |
+| value | uint256 | The amount of tokens to release |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| success | bool | Whether the withdrawal was successful |
+
 ### transferFrom
 
 Transfers `value` tokens from `from` to `to` using allowance mechanism.

--- a/docs/ConfidentialWrapper.md
+++ b/docs/ConfidentialWrapper.md
@@ -57,6 +57,39 @@ constructor(bool proxyMode, contract IERC20Metadata underlyingToken, string vers
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
+| proxyMode | bool | If true, disables initializers for proxy deployment.                  If false, initializes the contract directly. |
+| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. Ignored when proxyMode is true. |
+| version_ | string | Version of the wrapper. Ignored when proxyMode is true. |
+| initialAuthority | address | Initial authority address. Ignored when proxyMode is true. |
+
+### initialize
+
+Initializes the contract for proxy deployment.
+
+```solidity
+function initialize(contract IERC20Metadata underlyingToken, string version_, address initialAuthority) external
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. |
+| version_ | string | Version of the wrapper. |
+| initialAuthority | address | Initial authority address. |
+
+### depositForWithGasToken
+
+depositFor like function that allows to top up gas token wallet in the same transaction
+
+```solidity
+function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
 | account | address | The address to credit the wrapped tokens to |
 | value | uint256 | The amount of tokens to wrap |
 

--- a/docs/eip3009/ConfidentialEIP3009.md
+++ b/docs/eip3009/ConfidentialEIP3009.md
@@ -47,7 +47,7 @@ function encryptedTransferWithAuthorization(address from, address to, bytes valu
 Receive a transfer with a signed authorization from the payer
 
 ```solidity
-function encryptedReceiveWithAuthorization(address from, address to, bytes value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external
+function encryptedReceiveWithAuthorization(address from, address to, bytes value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external payable
 ```
 
 **dev:** _This has an additional check to ensure that the payee's address matches

--- a/docs/eip3009/ConfidentialEIP3009.md
+++ b/docs/eip3009/ConfidentialEIP3009.md
@@ -25,7 +25,7 @@ bytes32 ENCRYPTED_RECEIVE_WITH_AUTHORIZATION_TYPEHASH
 Execute a transfer with a signed authorization
 
 ```solidity
-function encryptedTransferWithAuthorization(address from, address to, bytes value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external
+function encryptedTransferWithAuthorization(address from, address to, bytes value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external payable
 ```
 
 #### Parameters

--- a/docs/interfaces/IConfidentialToken.md
+++ b/docs/interfaces/IConfidentialToken.md
@@ -463,7 +463,7 @@ function retrieveGasToken(uint256 amount, address receiver) external
 Transfers tokens to another holder
 
 ```solidity
-function encryptedTransfer(address to, bytes value) external
+function encryptedTransfer(address to, bytes value) external payable
 ```
 
 #### Parameters
@@ -478,7 +478,7 @@ function encryptedTransfer(address to, bytes value) external
 Transfers tokens from one holder to another using allowance
 
 ```solidity
-function encryptedTransferFrom(address from, address to, bytes value) external
+function encryptedTransferFrom(address from, address to, bytes value) external payable
 ```
 
 #### Parameters

--- a/docs/interfaces/IConfidentialToken.md
+++ b/docs/interfaces/IConfidentialToken.md
@@ -494,7 +494,7 @@ function encryptedTransferFrom(address from, address to, bytes value) external p
 Requests decryption of a single historic encrypted transfer payload with msg.sender as the viewer
 
 ```solidity
-function requestDecryptHistoricTransfer(bytes encryptedTransferData) external
+function requestDecryptHistoricTransfer(bytes encryptedTransferData) external payable
 ```
 
 **dev:** _Charges callbackFee from msg.sender even if not authorized to decrypt the payload_
@@ -510,7 +510,7 @@ function requestDecryptHistoricTransfer(bytes encryptedTransferData) external
 Requests decryption of a single historic encrypted transfer payload
 
 ```solidity
-function requestDecryptHistoricTransferFor(bytes encryptedTransferData, address historicViewer) external
+function requestDecryptHistoricTransferFor(bytes encryptedTransferData, address historicViewer) external payable
 ```
 
 **dev:** _Charges callbackFee from msg.sender even if not authorized to decrypt the payload_

--- a/docs/interfaces/IConfidentialWrapper.md
+++ b/docs/interfaces/IConfidentialWrapper.md
@@ -42,6 +42,22 @@ function releaseTo(address account, uint256 value) external
 | account | address | The address to release the underlying tokens to |
 | value | uint256 | The amount of tokens to release |
 
+### initialize
+
+Initializes the contract for proxy deployment.
+
+```solidity
+function initialize(contract IERC20Metadata underlyingToken, string version_, address initialAuthority) external
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. |
+| version_ | string | Version of the wrapper. |
+| initialAuthority | address | Initial authority address. |
+
 ### withdrawToWithGasToken
 
 withdrawTo like function that allows to top up gas token wallet in the same transaction

--- a/docs/interfaces/IConfidentialWrapper.md
+++ b/docs/interfaces/IConfidentialWrapper.md
@@ -4,6 +4,27 @@
 
 Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 
+### depositForWithGasToken
+
+depositFor like function that allows to top up gas token wallet in the same transaction
+
+```solidity
+function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account | address | The address to credit the wrapped tokens to |
+| value | uint256 | The amount of tokens to wrap |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| success | bool | Whether the deposit was successful |
+
 ### releaseTo
 
 Releases the caller's pending wrapped tokens to `account`.

--- a/docs/interfaces/IConfidentialWrapper.md
+++ b/docs/interfaces/IConfidentialWrapper.md
@@ -6,7 +6,8 @@ Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 
 ### depositForWithGasToken
 
-depositFor like function that allows to top up gas token wallet of the sender in the same transaction
+depositFor-like function
+that allows the sender to top up their gas token balance in the same transaction
 
 ```solidity
 function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
@@ -60,7 +61,8 @@ function initialize(contract IERC20Metadata underlyingToken, string version_, ad
 
 ### withdrawToWithGasToken
 
-withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
+withdrawTo-like function
+that allows the sender to top up their gas token balance in the same transaction
 
 ```solidity
 function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)

--- a/docs/interfaces/IConfidentialWrapper.md
+++ b/docs/interfaces/IConfidentialWrapper.md
@@ -42,19 +42,24 @@ function releaseTo(address account, uint256 value) external
 | account | address | The address to release the underlying tokens to |
 | value | uint256 | The amount of tokens to release |
 
-### initialize
+### withdrawToWithGasToken
 
-Initializes the contract for proxy deployment.
+withdrawTo like function that allows to top up gas token wallet in the same transaction
 
 ```solidity
-function initialize(contract IERC20Metadata underlyingToken, string version_, address initialAuthority) external
+function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)
 ```
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| underlyingToken | contract IERC20Metadata | Token to wrap confidentially. |
-| version_ | string | Version of the wrapper. |
-| initialAuthority | address | Initial authority address. |
+| account | address | The address to release the underlying tokens to |
+| value | uint256 | The amount of tokens to release |
+
+#### Return Values
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| success | bool | Whether the withdrawal was successful |
 

--- a/docs/interfaces/IConfidentialWrapper.md
+++ b/docs/interfaces/IConfidentialWrapper.md
@@ -6,7 +6,7 @@ Interface of ConfidentialWrapper that adds confidentiality to an ERC20 token
 
 ### depositForWithGasToken
 
-depositFor like function that allows to top up gas token wallet in the same transaction
+depositFor like function that allows to top up gas token wallet of the sender in the same transaction
 
 ```solidity
 function depositForWithGasToken(address account, uint256 value) external payable returns (bool success)
@@ -60,7 +60,7 @@ function initialize(contract IERC20Metadata underlyingToken, string version_, ad
 
 ### withdrawToWithGasToken
 
-withdrawTo like function that allows to top up gas token wallet in the same transaction
+withdrawTo like function that allows to top up gas token wallet of the sender in the same transaction
 
 ```solidity
 function withdrawToWithGasToken(address account, uint256 value) external payable returns (bool success)

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -399,6 +399,84 @@ describe("ConfidentialToken", () => {
         decryptedBalance.should.be.equal(amount);
     });
 
+    it("should allow encryptedTransfer with inline callback fee", async () => {
+        const amount = ethers.parseEther("1.0");
+        const [owner, recipient] = await ethers.getSigners();
+        const { token, bite } = await withMintedTokens();
+        const callbackFee = await token.callbackFee();
+
+        await token.connect(owner).setViewerPublicKey(
+            await getPublicKey(owner),
+            { value: callbackFee * 2n }
+        );
+        await bite.sendCallback();
+
+        await token.connect(recipient).setViewerPublicKey(
+            await getPublicKey(recipient),
+            { value: callbackFee * 2n }
+        );
+        await bite.sendCallback();
+
+        const ownerGasTokenBalance = await token.gasTokenBalanceOf(owner);
+        await token.connect(owner).retrieveGasToken(ownerGasTokenBalance, owner);
+        (await token.gasTokenBalanceOf(owner)).should.be.equal(0n);
+
+        const encryptedAmount = await token.encryptValue(owner.address, amount);
+        await token.connect(owner).encryptedTransfer(recipient, encryptedAmount, { value: callbackFee });
+
+        // funded and charged exactly once inline
+        (await token.gasTokenBalanceOf(owner)).should.be.equal(0n);
+
+        await bite.sendCallback();
+
+        (await token.gasTokenBalanceOf(owner)).should.be.equal(0n);
+        (await balanceOf(token, bite, recipient)).should.be.equal(amount);
+    });
+
+    it("should allow encryptedTransferFrom with inline callback fee", async () => {
+        const amount = ethers.parseEther("1.0");
+        const [owner, spender, recipient] = await ethers.getSigners();
+        const { token, bite } = await withMintedTokens();
+        const callbackFee = await token.callbackFee();
+        const overpayment = callbackFee * 3n;
+
+        await token.connect(owner).setViewerPublicKey(
+            await getPublicKey(owner),
+            { value: callbackFee * 2n }
+        );
+        await bite.sendCallback();
+
+        await token.connect(spender).setViewerPublicKey(
+            await getPublicKey(spender),
+            { value: callbackFee * 2n }
+        );
+        await bite.sendCallback();
+
+        await token.connect(recipient).setViewerPublicKey(
+            await getPublicKey(recipient),
+            { value: callbackFee * 2n }
+        );
+        await bite.sendCallback();
+
+        await token.connect(owner).approve(spender, amount);
+
+        const spenderGasTokenBalance = await token.gasTokenBalanceOf(spender);
+        await token.connect(spender).retrieveGasToken(spenderGasTokenBalance, spender);
+        (await token.gasTokenBalanceOf(spender)).should.be.equal(0n);
+
+        // For transferFrom the value must be salted to the spender, not the owner
+        const encryptedAmount = await token.encryptValue(spender.address, amount);
+        await token.connect(spender).encryptedTransferFrom(owner, recipient, encryptedAmount, { value: overpayment });
+
+        const expectedRemainder = overpayment - callbackFee;
+        (await token.gasTokenBalanceOf(spender)).should.be.equal(expectedRemainder);
+
+        await bite.sendCallback();
+
+        (await token.gasTokenBalanceOf(spender)).should.be.equal(expectedRemainder);
+        (await balanceOf(token, bite, recipient)).should.be.equal(amount);
+    });
+
     it("should not allow double spending during BITE execution", async () => {
         const amount = ethers.parseEther("1.0");
         const [owner, user1, user2] = await ethers.getSigners();
@@ -520,6 +598,8 @@ describe("ConfidentialToken", () => {
         await bite.sendCallback()
             .should.be.revertedWithCustomError(token, "ERC20InsufficientAllowance");
     });
+
+
 
     describe("Re Encryption of Historical transfers", () => {
         const gasTokenFunding = ethers.parseEther("1.0");
@@ -756,6 +836,37 @@ describe("ConfidentialToken", () => {
             await expect(callbackTx).to.emit(token, "ReEncryptedTransfer");
             expect(await decryptReEncryptedTransferValue(token, bite, viewer, callbackTx))
                 .to.equal(transferAmount);
+        });
+
+        it("should allow an unfunded viewer to call requestDecryptHistoricTransferFor with inline callbackFee", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient, viewer] = await ethers.getSigners();
+            await registerViewer(token, bite, owner, owner);
+            await registerViewer(token, bite, recipient, recipient);
+            await registerViewer(token, bite, viewer, viewer);
+
+            const event = await performTransferAndCapture(token, bite, owner, recipient, transferAmount);
+            await token.connect(owner).authorizeHistoricViewTransferId(viewer, event.transferId);
+
+            const callbackFee = await token.callbackFee();
+            const viewerGasTokenBalance = await token.gasTokenBalanceOf(viewer.address);
+            await token.connect(viewer).retrieveGasToken(viewerGasTokenBalance, viewer);
+            expect(await token.gasTokenBalanceOf(viewer.address)).to.equal(0);
+
+            await token.connect(viewer).requestDecryptHistoricTransferFor(
+                event.encryptedData,
+                viewer,
+                { value: callbackFee }
+            );
+
+            // Inline top-up is consumed exactly once by the callback
+            expect(await token.gasTokenBalanceOf(viewer.address)).to.equal(0);
+
+            const callbackTx = await bite.sendCallback();
+            await expect(callbackTx).to.emit(token, "ReEncryptedTransfer");
+            expect(await decryptReEncryptedTransferValue(token, bite, viewer, callbackTx))
+                .to.equal(transferAmount);
+            expect(await token.gasTokenBalanceOf(viewer.address)).to.equal(0);
         });
 
         it("should be able to grant historic view permission to a viewer with fromTimestamp and toTimestamp valid, and decrypt a transfer event", async () => {

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -599,8 +599,6 @@ describe("ConfidentialToken", () => {
             .should.be.revertedWithCustomError(token, "ERC20InsufficientAllowance");
     });
 
-
-
     describe("Re Encryption of Historical transfers", () => {
         const gasTokenFunding = ethers.parseEther("1.0");
         const transferAmount = ethers.parseEther("10.0");

--- a/test/ConfidentialWrapper.ts
+++ b/test/ConfidentialWrapper.ts
@@ -364,6 +364,62 @@ describe("ConfidentialWrapper", () => {
             .should.be.revertedWithCustomError(token, "ValueIsEncrypted");
     });
 
+    it("depositForWithGasToken works with zero gas-token balance", async () => {
+        const { token, underlyingToken, owner, bite } = await cleanWrapperDeployment();
+
+        const callbackFee = await token.callbackFee();
+        const availableGasTokenBalance = await token.gasTokenBalanceOf(owner);
+        await token.connect(owner).retrieveGasToken(availableGasTokenBalance, owner);
+        (await token.gasTokenBalanceOf(owner)).should.be.equal(0);
+
+        const amount = ethers.parseEther("1");
+        await underlyingToken.mint(owner, amount);
+        await underlyingToken.connect(owner).approve(token, amount);
+
+        await expect(
+            token.connect(owner).depositForWithGasToken(owner, amount, { value: callbackFee })
+        ).to.not.be.reverted;
+
+        (await token.requestedMints(owner)).should.be.equal(amount);
+        (await token.totalSupply()).should.be.equal(0);
+        (await underlyingToken.balanceOf(token)).should.be.equal(amount);
+        await expectWrapperInvariant(token, underlyingToken, [owner]);
+
+        await expect(bite.sendCallback()).to.not.be.reverted;
+
+        (await token.requestedMints(owner)).should.be.equal(0);
+        (await token.totalSupply()).should.be.equal(amount);
+        (await underlyingToken.balanceOf(token)).should.be.equal(amount);
+        await expectWrapperInvariant(token, underlyingToken, [owner]);
+    });
+
+    it("withdrawToWithGasToken works with zero gas-token balance", async () => {
+        const { token, underlyingToken, owner, bite, wrapped } = await withWrappedTokens();
+        const [, recipient] = await ethers.getSigners();
+
+        const callbackFee = await token.callbackFee();
+        const availableGasTokenBalance = await token.gasTokenBalanceOf(owner);
+        await token.connect(owner).retrieveGasToken(availableGasTokenBalance, owner);
+        (await token.gasTokenBalanceOf(owner)).should.be.equal(0);
+
+        const amount = wrapped / 2n;
+        await expect(
+            token.connect(owner).withdrawToWithGasToken(recipient, amount, { value: callbackFee })
+        ).to.not.be.reverted;
+
+        (await token.totalSupply()).should.be.equal(wrapped);
+        (await underlyingToken.balanceOf(token)).should.be.equal(wrapped);
+        (await underlyingToken.balanceOf(recipient)).should.be.equal(0);
+        await expectWrapperInvariant(token, underlyingToken, [owner]);
+
+        await expect(bite.sendCallback()).to.not.be.reverted;
+
+        (await token.totalSupply()).should.be.equal(wrapped - amount);
+        (await underlyingToken.balanceOf(token)).should.be.equal(wrapped - amount);
+        (await underlyingToken.balanceOf(recipient)).should.be.equal(amount);
+        await expectWrapperInvariant(token, underlyingToken, [owner]);
+    });
+
     describe("ConfidentialWrapper — requestedMints scenarios", () => {
 
         const topUpWrapperGasToken = async (


### PR DESCRIPTION
Add ability to provide gas token for CTX execution for following functions:
- encryptedTransferWithAuthorization
- encryptedReceiveWithAuthorization
- encryptedTransfer
- encryptedTransferFrom
- requestDecryptHistoricTransfer
- requestDecryptHistoricTransferFor

Add new functions with the functionality:
- depositForWithGasToken
- withdrawToWithGasToken

Add tests