### PR TITLE
Test improvements

### DIFF
--- a/contracts/test/CorruptingSubmitCTXMock.sol
+++ b/contracts/test/CorruptingSubmitCTXMock.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ *   CorruptingSubmitCTXMock.sol - confidential-token
+ *   Copyright (C) 2026-Present SKALE Labs
+ *   @author Eduardo Vasques
+ *
+ *   confidential-token is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   confidential-token is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with confidential-token.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pragma solidity ^0.8.27;
+
+import { CallbackSender } from "@skalenetwork/bite-solidity/test/CallbackSender.sol";
+import { PrecompiledMock } from "@skalenetwork/bite-solidity/test/PrecompiledMock.sol";
+
+/// @title ICorruptingSubmitCTXMock interface
+/// @author Eduardo Vasques
+/// @notice Faulty SUBMIT_CTX precompile mock. --- NO PRODUCTION USE ---
+interface ICorruptingSubmitCTXMock {
+    /// @notice Sets the decrypted arguments that the next callback will deliver verbatim.
+    /// @param decryptedArguments Arguments to pass to `onDecrypt` instead of honestly decrypting.
+    function setDecryptedArguments(bytes[] calldata decryptedArguments) external;
+
+    /// @notice Triggers the most recently created callback.
+    function sendCallback() external;
+}
+
+/// @title CorruptingSubmitCTXMock
+/// @author Eduardo Vasques
+/// @notice Test-only SUBMIT_CTX precompile mock that delivers attacker-chosen decrypted
+/// arguments to the supplicant's `onDecrypt` callback instead of faithfully decrypting the
+/// submitted cipher-texts.
+/// @notice DON'T USE IN PRODUCTION!
+/// @dev The production contract always constructs well-formed encrypted arguments and BITE
+/// protocol is trusted, so the defensive validation guards in
+/// `_validateDecryptedArguments` / `_decodeBalance` should never fire through the normal flow.
+/// Pointing `submitCTXAddress` at this mock (via `setSubmitCTXAddress`) lets a test deliver
+/// arbitrary decrypted arguments through a legitimately registered `CallbackSender`, which is
+/// the only way to exercise those guards. The plaintext arguments are forwarded unchanged so
+/// routing (`_parseAction`, `TransferInfo`) behaves exactly as in production.
+contract CorruptingSubmitCTXMock is PrecompiledMock, ICorruptingSubmitCTXMock {
+    bytes[] private _decryptedArguments;
+
+    /// @notice Address of the most recently created callback sender.
+    address payable public lastCallbackSender;
+
+    /// @inheritdoc ICorruptingSubmitCTXMock
+    function setDecryptedArguments(bytes[] calldata decryptedArguments) external override {
+        delete _decryptedArguments;
+        uint256 length = decryptedArguments.length;
+        for (uint256 i = 0; i < length; ++i) {
+            _decryptedArguments.push(decryptedArguments[i]);
+        }
+    }
+
+    /// @inheritdoc ICorruptingSubmitCTXMock
+    function sendCallback() external override {
+        CallbackSender(lastCallbackSender).sendCallback();
+    }
+
+
+    function _call(bytes calldata data) internal override returns (bytes memory result) {
+        (uint256 gasLimit, bytes memory innerData) = abi.decode(data, (uint256, bytes));
+        // Discard the real encrypted arguments; deliver the configured decrypted arguments.
+        (, bytes[] memory plaintextArguments) = abi.decode(innerData, (bytes[], bytes[]));
+        CallbackSender sender = new CallbackSender(
+            msg.sender,
+            gasLimit,
+            _decryptedArguments,
+            plaintextArguments
+        );
+        lastCallbackSender = payable(address(sender));
+        return abi.encodePacked(bytes20(uint160(address(sender))));
+    }
+}

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -27,11 +27,6 @@ describe("ConfidentialEIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
-    before(async function() {
-        // warmup the fixture
-        await withEIP3009Setup();
-    });
-
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         const latestBlock = await ethers.provider.getBlock("latest");

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -476,8 +476,6 @@ describe("ConfidentialEIP3009", () => {
         });
 
         it("reverts if the caller is not the payee", async () => {
-            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             const encryptedValue = await token.encryptValue(from, value);
 
@@ -495,7 +493,6 @@ describe("ConfidentialEIP3009", () => {
 
             // check initial balance
             expect(await balanceOf(token, bite, from)).to.equal(10e6);
-            expect(await balanceOf(token, bite, to)).to.equal(0);
 
             expect(await token.authorizationState(from, nonce)).to.be.eql(false);
 

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { BiteMock, ConfidentialToken } from "../typechain-types";
 import { withEIP3009Setup } from "./tools/fixtures";
 import { balanceOf, nowPlusSeconds } from "./tools/helpers";
+import { getPublicKey } from "./tools/cryptography";
 
 const ENCRYPTED_TRANSFER_WITH_AUTHORIZATION_TYPEHASH = ethers.id(
     "TransferWithAuthorization(address from,address to,bytes value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
@@ -429,6 +430,8 @@ describe("ConfidentialEIP3009", () => {
         });
 
         it("executes a transfer when a valid authorization is submitted by the payee", async () => {
+            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             const encryptedValue = await token.encryptValue(from, value);
 
@@ -477,6 +480,8 @@ describe("ConfidentialEIP3009", () => {
         });
 
         it("reverts if the caller is not the payee", async () => {
+            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             const encryptedValue = await token.encryptValue(from, value);
 

--- a/test/ConfidentialEIP3009.ts
+++ b/test/ConfidentialEIP3009.ts
@@ -28,8 +28,7 @@ describe("ConfidentialEIP3009", () => {
     const initialBalance = 10e6;
 
     before(async function() {
-        // warmup the fixture with larger timeout. This runs only once and is loaded in all following tests
-        this.timeout(60_000);
+        // warmup the fixture
         await withEIP3009Setup();
     });
 
@@ -73,6 +72,8 @@ describe("ConfidentialEIP3009", () => {
         });
 
         it("executes a transfer when a valid authorization is given", async () => {
+            await token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = transferParams;
             const encryptedValue = await token.encryptValue(from, value);
             // create an authorization to transfer money from Alice to Bob and sign

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -599,6 +599,74 @@ describe("ConfidentialToken", () => {
             .should.be.revertedWithCustomError(token, "ERC20InsufficientAllowance");
     });
 
+    describe("precompile address setters", () => {
+        it("allows the owner to update the EncryptECIES address", async () => {
+            const { token } = await cleanMintableDeployment();
+            const newAddress = ethers.Wallet.createRandom().address;
+            await token.setEncryptECIESAddress(newAddress)
+                .should.emit(token, "EncryptECIESAddressChanged").withArgs(newAddress);
+            (await token.encryptECIESAddress()).should.equal(newAddress);
+        });
+
+        it("allows the owner to update the EncryptTE address", async () => {
+            const { token } = await cleanMintableDeployment();
+            const newAddress = ethers.Wallet.createRandom().address;
+            await token.setEncryptTEAddress(newAddress)
+                .should.emit(token, "EncryptTEAddressChanged").withArgs(newAddress);
+            (await token.encryptTEAddress()).should.equal(newAddress);
+        });
+
+        it("allows the owner to update the SubmitCTX address", async () => {
+            const { token } = await cleanMintableDeployment();
+            const newAddress = ethers.Wallet.createRandom().address;
+            await token.setSubmitCTXAddress(newAddress)
+                .should.emit(token, "SubmitCTXAddressChanged").withArgs(newAddress);
+            (await token.submitCTXAddress()).should.equal(newAddress);
+        });
+
+        it("blocks unauthorized callers from setting EncryptECIES address", async () => {
+            const [, unauthorized] = await ethers.getSigners();
+            const { token } = await cleanMintableDeployment();
+            await token.connect(unauthorized).setEncryptECIESAddress(ethers.Wallet.createRandom().address)
+                .should.be.revertedWithCustomError(token, "AccessManagedUnauthorized")
+                .withArgs(unauthorized);
+        });
+
+        it("blocks unauthorized callers from setting EncryptTE address", async () => {
+            const [, unauthorized] = await ethers.getSigners();
+            const { token } = await cleanMintableDeployment();
+            await token.connect(unauthorized).setEncryptTEAddress(ethers.Wallet.createRandom().address)
+                .should.be.revertedWithCustomError(token, "AccessManagedUnauthorized")
+                .withArgs(unauthorized);
+        });
+
+        it("blocks unauthorized callers from setting SubmitCTX address", async () => {
+            const [, unauthorized] = await ethers.getSigners();
+            const { token } = await cleanMintableDeployment();
+            await token.connect(unauthorized).setSubmitCTXAddress(ethers.Wallet.createRandom().address)
+                .should.be.revertedWithCustomError(token, "AccessManagedUnauthorized")
+                .withArgs(unauthorized);
+        });
+
+        it("reverts when setting EncryptECIES address to zero", async () => {
+            const { token } = await cleanMintableDeployment();
+            await token.setEncryptECIESAddress(ethers.ZeroAddress)
+                .should.be.revertedWithCustomError(token, "ZeroAddress");
+        });
+
+        it("reverts when setting EncryptTE address to zero", async () => {
+            const { token } = await cleanMintableDeployment();
+            await token.setEncryptTEAddress(ethers.ZeroAddress)
+                .should.be.revertedWithCustomError(token, "ZeroAddress");
+        });
+
+        it("reverts when setting SubmitCTX address to zero", async () => {
+            const { token } = await cleanMintableDeployment();
+            await token.setSubmitCTXAddress(ethers.ZeroAddress)
+                .should.be.revertedWithCustomError(token, "ZeroAddress");
+        });
+    });
+
     describe("Re Encryption of Historical transfers", () => {
         const gasTokenFunding = ethers.parseEther("1.0");
         const transferAmount = ethers.parseEther("10.0");

--- a/test/ConfidentialToken.ts
+++ b/test/ConfidentialToken.ts
@@ -109,6 +109,15 @@ describe("ConfidentialToken", () => {
         (await token.gasTokenBalanceOf(owner)).should.be.equal(0);
     });
 
+    it("retrieveGasToken reverts when withdrawing more than the available balance", async () => {
+        const { token, owner } = await withMintedTokens();
+
+        const balance = await token.gasTokenBalanceOf(owner);
+        await token.connect(owner).retrieveGasToken(balance + 1n, owner)
+            .should.be.revertedWithCustomError(token, "InsufficientGasToken")
+            .withArgs(balance + 1n, balance);
+    });
+
     it("should not return token balance", async () => {
         const { token } = await cleanMintableDeployment();
         const [owner] = await ethers.getSigners();
@@ -362,6 +371,34 @@ describe("ConfidentialToken", () => {
 
         const decryptedBalance = await balanceOf(token, bite, recipient);
         decryptedBalance.should.be.equal(amount);
+    });
+
+    it("encryptedTransferFrom reverts with ERC20InvalidSender when from is the zero address", async () => {
+        const [, spender, recipient] = await ethers.getSigners();
+        const { token } = await withMintedTokens();
+
+        // The sender guard is checked before the value is decoded, so any payload reverts.
+        await token.connect(spender).encryptedTransferFrom(ethers.ZeroAddress, recipient, "0x")
+            .should.be.revertedWithCustomError(token, "ERC20InvalidSender")
+            .withArgs(ethers.ZeroAddress);
+    });
+
+    it("encryptedTransferFrom reverts with ERC20InvalidReceiver when to is the zero address", async () => {
+        const [owner, spender] = await ethers.getSigners();
+        const { token } = await withMintedTokens();
+
+        await token.connect(spender).encryptedTransferFrom(owner, ethers.ZeroAddress, "0x")
+            .should.be.revertedWithCustomError(token, "ERC20InvalidReceiver")
+            .withArgs(ethers.ZeroAddress);
+    });
+
+    it("encryptedTransfer reverts with ERC20InvalidReceiver when to is the zero address", async () => {
+        const { token, owner } = await withMintedTokens();
+
+        // `from` is always msg.sender (non-zero), so only the receiver guard is reachable here.
+        await token.connect(owner).encryptedTransfer(ethers.ZeroAddress, "0x")
+            .should.be.revertedWithCustomError(token, "ERC20InvalidReceiver")
+            .withArgs(ethers.ZeroAddress);
     });
 
     it("should be able to transferFrom with encrypted values", async () => {
@@ -1315,6 +1352,50 @@ describe("ConfidentialToken", () => {
             await token.connect(owner).removeHistoricViewTransferId(viewer, 0);
         });
 
+        // The three removal entry points have no onlyRegisteredUser modifier, so no viewer
+        // registration is needed to reach the branches they exercise.
+
+        it("removeHistoricViewTransferId reverts for a transferId that does not exist yet", async () => {
+            const { token } = await cleanMintableDeployment();
+            const [owner, viewer] = await ethers.getSigners();
+
+            await token.connect(owner).removeHistoricViewTransferId(viewer, 9999)
+                .should.be.revertedWithCustomError(token, "InvalidTransferId");
+        });
+
+        it("removeHistoricViewAuth is a no-op (emits nothing) when nothing was authorized", async () => {
+            const { token } = await cleanMintableDeployment();
+            const [owner, viewer] = await ethers.getSigners();
+
+            await expect(token.connect(owner).removeHistoricViewAuth(viewer))
+                .to.not.emit(token, "HistoricViewPermissionsRevoked");
+        });
+
+        it("removeHistoricViewTimeRange is a no-op (emits nothing) when no time range was authorized", async () => {
+            const { token } = await cleanMintableDeployment();
+            const [owner, viewer] = await ethers.getSigners();
+
+            await expect(token.connect(owner).removeHistoricViewTimeRange(viewer))
+                .to.not.emit(token, "HistoricViewTimeRangeRevoked");
+        });
+
+        it("authorizeHistoricViewTransferId is idempotent: re-authorizing the same id emits nothing", async () => {
+            const { token, bite, owner } = await withMintedTokens();
+            const [, recipient, viewer] = await ethers.getSigners();
+            await registerViewer(token, bite, owner, owner);
+            await registerViewer(token, bite, recipient, recipient);
+            await registerViewer(token, bite, viewer, viewer);
+
+            const event = await performTransferAndCapture(token, bite, owner, recipient, transferAmount);
+
+            // First authorization emits the event...
+            await expect(token.connect(owner).authorizeHistoricViewTransferId(viewer, event.transferId))
+                .to.emit(token, "HistoricViewTransferIdAuthorized");
+            // ...re-authorizing the same id is a no-op and emits nothing.
+            await expect(token.connect(owner).authorizeHistoricViewTransferId(viewer, event.transferId))
+                .to.not.emit(token, "HistoricViewTransferIdAuthorized");
+        });
+
         // Automatic TransferValueEncryptedForRecipient on transfer
 
         it("should automatically emit TransferValueEncryptedForRecipient & Sender readable by the viewers when they have a registered viewer", async () => {
@@ -1696,6 +1777,78 @@ describe("ConfidentialToken", () => {
             await token.connect(attacker).encryptedTransfer(sink, zeroBalanceCt);
             await expect(bite.sendCallback())
                 .to.be.revertedWithCustomError(token, "InvalidSaltForTransactionValue");
+        });
+    });
+
+    // Defensive callback-validation guards.
+    //
+    // In production the contract always builds well-formed encrypted arguments and BITE protocol is trusted, so the malformed-argument guards in
+    // _validateDecryptedArguments / _decodeBalance should never fire through the normal flow. We
+    // point submitCTXAddress at CorruptingSubmitCTXMock, which delivers attacker-chosen decrypted
+    // arguments through a legitimately registered CallbackSender (the only way to reach these
+    // guards), while forwarding the real plaintext arguments so routing is unchanged.
+    describe("malformed decrypted callback arguments", () => {
+        const coder = ethers.AbiCoder.defaultAbiCoder();
+        const bytesOfLength = (length: number) => ethers.hexlify(ethers.randomBytes(length));
+        const encodeBalance = (holder: string, value: bigint) =>
+            coder.encode(["address", "uint256"], [holder, value]);
+
+        // Each case delivers a different malformed shape to a real owner -> recipient transfer.
+        // A reverting callback rolls back token state, so all cases share one fixture and one
+        // deployed mock; only the gas-token fee for each queued transfer is consumed.
+        it("rejects every malformed decrypted-argument shape on the transfer callback", async () => {
+            const { token, owner } = await withMintedTokens();
+            const [, recipient] = await ethers.getSigners();
+            const validValue = encodeBalance(owner.address, ethers.parseEther("1"));
+
+            const mock = await (await ethers.getContractFactory("CorruptingSubmitCTXMock")).deploy();
+            await token.connect(owner).setSubmitCTXAddress(mock);
+
+            const cases: { label: string; args: string[]; error: string }[] = [
+                {
+                    label: "argument count is neither 2 nor 3",
+                    args: [bytesOfLength(64)],
+                    error: "DecryptionBadFormat"
+                },
+                {
+                    // Length 2 implies mint or burn, which requires exactly one of from/to to be
+                    // zero. A genuine transfer has both non-zero, so the check rejects it.
+                    label: "2-argument payload on a real (non mint/burn) transfer",
+                    args: [bytesOfLength(64), bytesOfLength(64)],
+                    error: "DecryptionBadFormat"
+                },
+                {
+                    label: "recipient balance argument has an invalid length",
+                    args: [bytesOfLength(64), bytesOfLength(32), bytesOfLength(64)],
+                    error: "DecryptionBadFormat"
+                },
+                {
+                    label: "sender balance argument has an invalid length",
+                    args: [bytesOfLength(32), bytesOfLength(64), bytesOfLength(64)],
+                    error: "DecryptionBadFormat"
+                },
+                {
+                    label: "value argument is not exactly 64 bytes",
+                    args: [bytesOfLength(64), bytesOfLength(64), bytesOfLength(32)],
+                    error: "DecryptionBadFormat"
+                },
+                {
+                    // arg[0] is empty: _decodeBalance returns (address(0), 0), so the salt check
+                    // fails because the decoded holder (zero) does not match the expected `from`.
+                    // The value argument (arg[2]) is verified first and must be salted to `from`.
+                    label: "empty balance argument decodes to the zero address and fails the salt check",
+                    args: ["0x", validValue, validValue],
+                    error: "InvalidSaltForTransactionValue"
+                }
+            ];
+
+            for (const { args, error } of cases) {
+                await mock.setDecryptedArguments(args);
+                await token.connect(owner).transfer(recipient, ethers.parseEther("1"));
+                await mock.sendCallback()
+                        .should.be.revertedWithCustomError(token, error);
+
+            }
         });
     });
 });

--- a/test/ConfidentialWrapper.ts
+++ b/test/ConfidentialWrapper.ts
@@ -364,6 +364,31 @@ describe("ConfidentialWrapper", () => {
             .should.be.revertedWithCustomError(token, "ValueIsEncrypted");
     });
 
+    it("transferFrom moves the confidential balance through the allowance mechanism", async () => {
+        const { token, bite, owner } = await withWrappedTokens();
+        const [, spender, recipient] = await ethers.getSigners();
+        const amount = ethers.parseEther("10");
+
+        // Recipient needs a registered viewer so we can decrypt and assert its balance.
+        await token.connect(recipient).setViewerPublicKey(
+            await getPublicKey(recipient),
+            { value: ethers.parseEther("1") }
+        );
+        await bite.sendCallback();
+        // The spender (gas payer of the delegated transfer) funds the callback fee.
+        await token.connect(spender).fundWithGasToken(spender, { value: ethers.parseEther("1") });
+
+        await token.connect(owner).approve(spender, amount);
+        expect(await token.allowance(owner, spender)).to.equal(amount);
+
+        await token.connect(spender).transferFrom(owner, recipient, amount);
+        await bite.sendCallback();
+
+        // Allowance is consumed and the value lands on the recipient's confidential balance.
+        expect(await token.allowance(owner, spender)).to.equal(0n);
+        expect(await balanceOf(token, bite, recipient)).to.equal(amount);
+    });
+
     it("depositForWithGasToken works with zero gas-token balance", async () => {
         const { token, underlyingToken, owner, bite } = await cleanWrapperDeployment();
 

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -933,6 +933,24 @@ describe("EIP3009", () => {
                 cancellation.s
             ).should.be.revertedWithCustomError(token, "AuthorizationUsedError").withArgs(alice, nonce);
         });
+
+        it("reverts if the cancellation is not signed by the authorizer", async () => {
+            // Sign a cancellation with Bob's key, then submit it claiming Alice is the
+            // authorizer. The recovered signer no longer matches `authorizer`.
+            const cancellation = await signCancelAuthorization(
+                nonce,
+                domainSeparator,
+                bob
+            );
+
+            await token.connect(charlie).cancelAuthorization(
+                alice,
+                nonce,
+                cancellation.v,
+                cancellation.r,
+                cancellation.s
+            ).should.be.revertedWithCustomError(token, "InvalidSignature");
+        });
     });
 });
 

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -30,11 +30,6 @@ describe("EIP3009", () => {
     let nonce: string;
     const initialBalance = 10e6;
 
-    before(async function() {
-        // warmup the fixture with larger timeout. This runs only once and is loaded in all following tests
-        await withEIP3009Setup();
-    });
-
     beforeEach(async () => {
         ({ bite, token, alice, bob, charlie } = await withEIP3009Setup());
         const latestBlock = await ethers.provider.getBlock("latest");

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -6,6 +6,7 @@ import { expect } from "chai";
 import { BiteMock, ConfidentialToken } from "../typechain-types";
 import { withEIP3009Setup } from "./tools/fixtures";
 import { balanceOf, nowPlusSeconds } from "./tools/helpers";
+import { getPublicKey } from "./tools/cryptography";
 
 const TRANSFER_WITH_AUTHORIZATION_TYPEHASH = ethers.id(
     "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
@@ -426,6 +427,8 @@ describe("EIP3009", () => {
 
 
         it("executes a transfer when a valid authorization is submitted by the payee", async () => {
+            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             // create a receive authorization to transfer money from Alice to Charlie
             // and sign with Alice's key
@@ -472,6 +475,8 @@ describe("EIP3009", () => {
         });
 
         it("reverts if the caller is not the payee", async () => {
+            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             // create a signed authorization
             const { v, r, s } = await signReceiveAuthorization(

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -32,7 +32,6 @@ describe("EIP3009", () => {
 
     before(async function() {
         // warmup the fixture with larger timeout. This runs only once and is loaded in all following tests
-        this.timeout(60_000);
         await withEIP3009Setup();
     });
 
@@ -80,6 +79,8 @@ describe("EIP3009", () => {
         });
 
         it("executes a transfer when a valid authorization is given", async () => {
+            await token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
+            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = transferParams;
             // create an authorization to transfer money from Alice to Bob and sign
             // with Alice's key

--- a/test/EIP3009.ts
+++ b/test/EIP3009.ts
@@ -471,8 +471,6 @@ describe("EIP3009", () => {
         });
 
         it("reverts if the caller is not the payee", async () => {
-            await token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-            await bite.sendCallback();
             const { from, to, value, validAfter, validBefore } = receiveParams;
             // create a signed authorization
             const { v, r, s } = await signReceiveAuthorization(
@@ -488,7 +486,6 @@ describe("EIP3009", () => {
 
             // check initial balance
             expect((await balanceOf(token, bite, from))).to.equal(10e6);
-            expect((await balanceOf(token, bite, to))).to.equal(0);
 
             expect(await token.authorizationState(from, nonce)).to.be.eql(false);
 

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -172,8 +172,8 @@ const eip3009Fixture = async () => {
 
     await context.token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
     await context.bite.sendCallback();
-    await context.token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
-    await context.bite.sendCallback();
+    //await context.token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
+    //await context.bite.sendCallback();
     //await context.token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
     //await context.bite.sendCallback();
     // End: Time consuming section under coverage

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -166,16 +166,12 @@ const eip3009Fixture = async () => {
         await context.token.connect(user).fundWithGasToken(user, { value: ethers.parseEther("3") });
     }
 
-    // Start: Time consuming section under coverage
+    // Start: Time consuming section under coverage. Avoid unnecessary registrations and callbacks
     await context.token.transfer(alice, 10e6);
     await context.bite.sendCallback();
 
     await context.token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
     await context.bite.sendCallback();
-    //await context.token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
-    //await context.bite.sendCallback();
-    //await context.token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-    //await context.bite.sendCallback();
     // End: Time consuming section under coverage
 
     return { ...context, alice, bob, charlie, minted };

--- a/test/tools/fixtures.ts
+++ b/test/tools/fixtures.ts
@@ -1,5 +1,6 @@
 import {
-    loadFixture
+    loadFixture,
+    setCode
 } from "@nomicfoundation/hardhat-network-helpers";
 import { ethers } from "hardhat";
 import { HDNodeWallet, Wallet } from "ethers";
@@ -25,6 +26,21 @@ const deployBiteMocks = async () => {
     const encryptTE = await encryptTEFactory.deploy(bite);
     const submitCTXFactory = await ethers.getContractFactory("SubmitCTXMock");
     const submitCTX = await submitCTXFactory.deploy(bite);
+
+    // Set precompiles at predefined addresses
+    await setCode(
+        "0x000000000000000000000000000000000000001c", // ENCRYPT_ECIES_ADDRESS
+        await ethers.provider.getCode(encryptECIES)
+    );
+    await setCode(
+        "0x000000000000000000000000000000000000001d", // ENCRYPT_TE_ADDRESS
+        await ethers.provider.getCode(encryptTE)
+    );
+    await setCode(
+        "0x000000000000000000000000000000000000001b", // SUBMIT_CTX_ADDRESS
+        await ethers.provider.getCode(submitCTX)
+    );
+
     return {
         bite,
         encryptECIES,
@@ -53,9 +69,6 @@ const deployMintableFixture = async () => {
     const mintableConfidentialToken = deployedContracts.MintableConfidentialToken as MintableConfidentialToken;
 
     const mocks = await deployBiteMocks();
-    await mintableConfidentialToken.setEncryptECIESAddress(mocks.encryptECIES);
-    await mintableConfidentialToken.setEncryptTEAddress(mocks.encryptTE);
-    await mintableConfidentialToken.setSubmitCTXAddress(mocks.submitCTX);
     await mintableConfidentialToken.setCallbackFee(ethers.parseEther("0.003"));
 
     return {
@@ -100,9 +113,6 @@ const deployWrapperFixture = async () => {
     });
 
     const mocks = await deployBiteMocks();
-    await contracts.ConfidentialWrapper.setEncryptECIESAddress(mocks.encryptECIES);
-    await contracts.ConfidentialWrapper.setEncryptTEAddress(mocks.encryptTE);
-    await contracts.ConfidentialWrapper.setSubmitCTXAddress(mocks.submitCTX);
     await contracts.ConfidentialWrapper.setCallbackFee(ethers.parseEther("0.003"));
 
     return {
@@ -144,25 +154,29 @@ const eip3009Fixture = async () => {
     const minted = ethers.parseEther("1000");
     const gasTokenBalance = ethers.parseEther("1.0");
     const context = await deployMintableFixture();
+
     await context.owner.sendTransaction({
         to: await ethers.resolveAddress(context.token),
         value: gasTokenBalance
     });
     await context.token.mint(context.owner, minted);
     await context.bite.sendCallback();
-
     await feedAccounts([alice, bob, charlie]);
     for (const user of [alice, bob, charlie]) {
         await context.token.connect(user).fundWithGasToken(user, { value: ethers.parseEther("3") });
     }
+
+    // Start: Time consuming section under coverage
+    await context.token.transfer(alice, 10e6);
+    await context.bite.sendCallback();
+
     await context.token.connect(alice).setViewerPublicKey(await getPublicKey(alice));
     await context.bite.sendCallback();
     await context.token.connect(bob).setViewerPublicKey(await getPublicKey(bob));
     await context.bite.sendCallback();
-    await context.token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
-    await context.bite.sendCallback();
-    await context.token.transfer(alice, 10e6);
-    await context.bite.sendCallback();
+    //await context.token.connect(charlie).setViewerPublicKey(await getPublicKey(charlie));
+    //await context.bite.sendCallback();
+    // End: Time consuming section under coverage
 
     return { ...context, alice, bob, charlie, minted };
 };


### PR DESCRIPTION
Fixes #94 
- Remove charlie and Bob PubKey registration from EIP3009 default setup.
- Add tests for ConfidentialToken setters.
- Replace use of setters in setup, and set precompiles at default addresses in real SKALE chains, using hardhat cheatcode.